### PR TITLE
Allow dAPI names to be reset

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -715,9 +715,9 @@ contract DapiServer is
             readerCanReadDataFeed(dapiNameHash, msg.sender),
             "Sender cannot read"
         );
-        DataFeed storage dataFeed = dataFeeds[
-            dapiNameHashToDataFeedId[dapiNameHash]
-        ];
+        bytes32 dataFeedId = dapiNameHashToDataFeedId[dapiNameHash];
+        require(dataFeedId != bytes32(0), "dAPI name not set");
+        DataFeed storage dataFeed = dataFeeds[dataFeedId];
         return (dataFeed.value, dataFeed.timestamp);
     }
 

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -654,7 +654,6 @@ contract DapiServer is
         override
     {
         require(dapiName != bytes32(0), "dAPI name zero");
-        require(dataFeedId != bytes32(0), "Data feed ID zero");
         require(
             msg.sender == manager ||
                 IAccessControlRegistry(accessControlRegistry).hasRole(

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -3076,6 +3076,14 @@ describe('DapiServer', function () {
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
       });
+      context('dAPI name not set', function () {
+        it('reverts', async function () {
+          const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+          await expect(dapiServer.connect(voidSignerAddressZero).readWithDapiName(dapiName)).to.be.revertedWith(
+            'dAPI name not set'
+          );
+        });
+      });
     });
     context('Reader is whitelisted', function () {
       context('dAPI name set to Beacon', function () {
@@ -3119,6 +3127,21 @@ describe('DapiServer', function () {
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
       });
+      context('dAPI name not set', function () {
+        it('reverts', async function () {
+          const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+          // Whitelist for the dAPI name hash
+          const dapiNameHash = hre.ethers.utils.keccak256(
+            hre.ethers.utils.defaultAbiCoder.encode(['bytes32'], [dapiName])
+          );
+          await dapiServer
+            .connect(roles.indefiniteWhitelister)
+            .setIndefiniteWhitelistStatus(dapiNameHash, roles.randomPerson.address, true);
+          await expect(dapiServer.connect(roles.randomPerson).readWithDapiName(dapiName)).to.be.revertedWith(
+            'dAPI name not set'
+          );
+        });
+      });
     });
     context('Reader is unlimited reader', function () {
       context('dAPI name set to Beacon', function () {
@@ -3148,6 +3171,14 @@ describe('DapiServer', function () {
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
       });
+      context('dAPI name not set', function () {
+        it('reverts', async function () {
+          const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+          await expect(dapiServer.connect(roles.unlimitedReader).readWithDapiName(dapiName)).to.be.revertedWith(
+            'dAPI name not set'
+          );
+        });
+      });
     });
     context('Reader is none of the above', function () {
       context('dAPI name set to Beacon', function () {
@@ -3167,6 +3198,12 @@ describe('DapiServer', function () {
             'Sender cannot read'
           );
         });
+      });
+      it('reverts', async function () {
+        const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+        await expect(dapiServer.connect(roles.randomPerson).readWithDapiName(dapiName)).to.be.revertedWith(
+          'Sender cannot read'
+        );
       });
     });
   });

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -2918,11 +2918,23 @@ describe('DapiServer', function () {
         });
       });
       context('Data feed ID is zero', function () {
-        it('reverts', async function () {
-          const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
-          await expect(
-            dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, hre.ethers.constants.HashZero)
-          ).to.be.revertedWith('Data feed ID zero');
+        context('Sender is dAPI name setter', function () {
+          it('sets dAPI name', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            await expect(dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, hre.ethers.constants.HashZero))
+              .to.emit(dapiServer, 'SetDapiName')
+              .withArgs(dapiName, hre.ethers.constants.HashZero, roles.dapiNameSetter.address);
+            expect(await dapiServer.dapiNameToDataFeedId(dapiName)).to.equal(hre.ethers.constants.HashZero);
+          });
+        });
+        context('Sender is not dAPI name setter', function () {
+          it('reverts', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await expect(
+              dapiServer.connect(roles.randomPerson).setDapiName(dapiName, hre.ethers.constants.HashZero)
+            ).to.be.revertedWith('Sender cannot set dAPI name');
+          });
         });
       });
     });

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -2926,6 +2926,9 @@ describe('DapiServer', function () {
               .to.emit(dapiServer, 'SetDapiName')
               .withArgs(dapiName, hre.ethers.constants.HashZero, roles.dapiNameSetter.address);
             expect(await dapiServer.dapiNameToDataFeedId(dapiName)).to.equal(hre.ethers.constants.HashZero);
+            // Check if we can still set the dAPI name
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            expect(await dapiServer.dapiNameToDataFeedId(dapiName)).to.equal(beaconSetId);
           });
         });
         context('Sender is not dAPI name setter', function () {


### PR DESCRIPTION
I was in a call with a major use case and they asked if we had an on-chain registry for data feeds that people can generate on-chain assets out of in a permisionless way. We almost already have that with the dAPI names and this PR completes it by:
- Allowing us to reset dAPI names, which allows us to disable names that are not actively used
- And since the above implies that all names that are set to a data feed ID are active, it reverts if the user tries to read using a dAPI name that is not set