### PR TITLE
Implement a read function at DapiServer that reads a single uint256

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -685,7 +685,7 @@ contract DapiServer is
     /// @param dataFeedId Data feed ID
     /// @return value Data feed value
     /// @return timestamp Data feed timestamp
-    function readWithDataFeedId(bytes32 dataFeedId)
+    function readDataFeedWithId(bytes32 dataFeedId)
         external
         view
         override
@@ -699,13 +699,13 @@ contract DapiServer is
         return (dataFeed.value, dataFeed.timestamp);
     }
 
-    /// @notice Reads the dAPI with name
+    /// @notice Reads the data feed with dAPI name
     /// @dev The read data feed may belong to a Beacon or dAPI. The reader
     /// must be whitelisted for the hash of the dAPI name.
     /// @param dapiName dAPI name
     /// @return value Data feed value
     /// @return timestamp Data feed timestamp
-    function readWithDapiName(bytes32 dapiName)
+    function readDataFeedWithDapiName(bytes32 dapiName)
         external
         view
         override

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -699,6 +699,24 @@ contract DapiServer is
         return (dataFeed.value, dataFeed.timestamp);
     }
 
+    /// @notice Reads the data feed value with ID
+    /// @param dataFeedId Data feed ID
+    /// @return value Data feed value
+    function readDataFeedValueWithId(bytes32 dataFeedId)
+        external
+        view
+        override
+        returns (int256 value)
+    {
+        require(
+            readerCanReadDataFeed(dataFeedId, msg.sender),
+            "Sender cannot read"
+        );
+        DataFeed storage dataFeed = dataFeeds[dataFeedId];
+        require(dataFeed.timestamp != 0, "Data feed does not exist");
+        return dataFeed.value;
+    }
+
     /// @notice Reads the data feed with dAPI name
     /// @dev The read data feed may belong to a Beacon or dAPI. The reader
     /// must be whitelisted for the hash of the dAPI name.

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -706,7 +706,7 @@ contract DapiServer is
         external
         view
         override
-        returns (int256 value)
+        returns (int224 value)
     {
         require(
             readerCanReadDataFeed(dataFeedId, msg.sender),
@@ -747,7 +747,7 @@ contract DapiServer is
         external
         view
         override
-        returns (int256 value)
+        returns (int224 value)
     {
         bytes32 dapiNameHash = keccak256(abi.encodePacked(dapiName));
         require(

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -740,6 +740,27 @@ contract DapiServer is
         return (dataFeed.value, dataFeed.timestamp);
     }
 
+    /// @notice Reads the data feed value with dAPI name
+    /// @param dapiName dAPI name
+    /// @return value Data feed value
+    function readDataFeedValueWithDapiName(bytes32 dapiName)
+        external
+        view
+        override
+        returns (int256 value)
+    {
+        bytes32 dapiNameHash = keccak256(abi.encodePacked(dapiName));
+        require(
+            readerCanReadDataFeed(dapiNameHash, msg.sender),
+            "Sender cannot read"
+        );
+        DataFeed storage dataFeed = dataFeeds[
+            dapiNameHashToDataFeedId[dapiNameHash]
+        ];
+        require(dataFeed.timestamp != 0, "Data feed does not exist");
+        return dataFeed.value;
+    }
+
     /// @notice Returns if a reader can read the data feed
     /// @param dataFeedId Data feed ID (or dAPI name hash)
     /// @param reader Reader address

--- a/contracts/dapis/interfaces/IDapiReader.sol
+++ b/contracts/dapis/interfaces/IDapiReader.sol
@@ -8,12 +8,12 @@ interface IDapiReader {
 /// @dev We use the part of the interface that will persist between
 /// DapiServer versions
 interface IBaseDapiServer {
-    function readWithDataFeedId(bytes32 dataFeedId)
+    function readDataFeedWithId(bytes32 dataFeedId)
         external
         view
         returns (int224 value, uint32 timestamp);
 
-    function readWithDapiName(bytes32 dapiName)
+    function readDataFeedWithDapiName(bytes32 dapiName)
         external
         view
         returns (int224 value, uint32 timestamp);

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -175,12 +175,12 @@ interface IDapiServer is IAirnodeRequester {
         view
         returns (bytes32);
 
-    function readWithDataFeedId(bytes32 dataFeedId)
+    function readDataFeedWithId(bytes32 dataFeedId)
         external
         view
         returns (int224 value, uint32 timestamp);
 
-    function readWithDapiName(bytes32 dapiName)
+    function readDataFeedWithDapiName(bytes32 dapiName)
         external
         view
         returns (int224 value, uint32 timestamp);

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -183,7 +183,7 @@ interface IDapiServer is IAirnodeRequester {
     function readDataFeedValueWithId(bytes32 dataFeedId)
         external
         view
-        returns (int256 value);
+        returns (int224 value);
 
     function readDataFeedWithDapiName(bytes32 dapiName)
         external
@@ -193,7 +193,7 @@ interface IDapiServer is IAirnodeRequester {
     function readDataFeedValueWithDapiName(bytes32 dapiName)
         external
         view
-        returns (int256 value);
+        returns (int224 value);
 
     function readerCanReadDataFeed(bytes32 dataFeedId, address reader)
         external

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -180,6 +180,11 @@ interface IDapiServer is IAirnodeRequester {
         view
         returns (int224 value, uint32 timestamp);
 
+    function readDataFeedValueWithId(bytes32 dataFeedId)
+        external
+        view
+        returns (int256 value);
+
     function readDataFeedWithDapiName(bytes32 dapiName)
         external
         view

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -190,6 +190,11 @@ interface IDapiServer is IAirnodeRequester {
         view
         returns (int224 value, uint32 timestamp);
 
+    function readDataFeedValueWithDapiName(bytes32 dapiName)
+        external
+        view
+        returns (int256 value);
+
     function readerCanReadDataFeed(bytes32 dataFeedId, address reader)
         external
         view

--- a/contracts/dapis/mock/MockDapiReader.sol
+++ b/contracts/dapis/mock/MockDapiReader.sol
@@ -15,7 +15,7 @@ contract MockDapiReader is DapiReader {
         view
         returns (int224 value, uint32 timestamp)
     {
-        return IBaseDapiServer(dapiServer).readWithDataFeedId(dataFeedId);
+        return IBaseDapiServer(dapiServer).readDataFeedWithId(dataFeedId);
     }
 
     function exposedReadWithDapiName(bytes32 dapiName)
@@ -23,6 +23,6 @@ contract MockDapiReader is DapiReader {
         view
         returns (int224 value, uint32 timestamp)
     {
-        return IBaseDapiServer(dapiServer).readWithDapiName(dapiName);
+        return IBaseDapiServer(dapiServer).readDataFeedWithDapiName(dapiName);
     }
 }

--- a/test/dapis/DapiReader.sol.js
+++ b/test/dapis/DapiReader.sol.js
@@ -84,7 +84,7 @@ describe('DapiReader', function () {
     });
   });
 
-  describe('readWithDataFeedId', function () {
+  describe('readDataFeedWithId', function () {
     context('DapiReader is whitelisted', function () {
       it('reads with data feed ID', async function () {
         await dapiServer1.connect(roles.manager).setIndefiniteWhitelistStatus(beaconId, dapiReader.address, true);
@@ -100,7 +100,7 @@ describe('DapiReader', function () {
     });
   });
 
-  describe('readWithDapiName', function () {
+  describe('readDataFeedWithDapiName', function () {
     context('DapiReader is whitelisted', function () {
       it('reads with dAPI name', async function () {
         const dapiNameHash = hre.ethers.utils.keccak256(

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -3017,7 +3017,7 @@ describe('DapiServer', function () {
         });
       });
     });
-    context('Reader is none of the above', function () {
+    context('Reader is not zero address, whitelisted or unlimited reader', function () {
       context('Data feed is Beacon', function () {
         it('reverts', async function () {
           await expect(dapiServer.connect(roles.randomPerson).readDataFeedWithId(beaconId)).to.be.revertedWith(
@@ -3171,7 +3171,7 @@ describe('DapiServer', function () {
         });
       });
     });
-    context('Reader is none of the above', function () {
+    context('Reader is not zero address, whitelisted or unlimited reader', function () {
       it('reverts', async function () {
         await expect(dapiServer.connect(roles.randomPerson).readDataFeedValueWithId(beaconId)).to.be.revertedWith(
           'Sender cannot read'
@@ -3282,7 +3282,7 @@ describe('DapiServer', function () {
         });
       });
     });
-    context('Reader is none of the above', function () {
+    context('Reader is not zero address, whitelisted or unlimited reader', function () {
       context('dAPI name set to Beacon', function () {
         it('reverts', async function () {
           const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
@@ -3484,7 +3484,7 @@ describe('DapiServer', function () {
         });
       });
     });
-    context('Reader is none of the above', function () {
+    context('Reader is not zero address, whitelisted or unlimited reader', function () {
       it('reverts', async function () {
         const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
         await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
@@ -3521,7 +3521,7 @@ describe('DapiServer', function () {
         ).to.equal(true);
       });
     });
-    context('Reader is none of the above', function () {
+    context('Reader is not zero address, whitelisted or unlimited reader', function () {
       it('returns false for all data feeds', async function () {
         expect(
           await dapiServer.readerCanReadDataFeed(testUtils.generateRandomBytes32(), roles.randomPerson.address)

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -3304,6 +3304,197 @@ describe('DapiServer', function () {
     });
   });
 
+  describe('readDataFeedValueWithDapiName', function () {
+    context('Reader is zero address', function () {
+      context('Data feed is Beacon', function () {
+        context('Beacon is initialized', function () {
+          it('reads Beacon', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeacon(templateId, 123, timestamp);
+            const beaconValue = await dapiServer.connect(voidSignerAddressZero).readDataFeedValueWithDapiName(dapiName);
+            expect(beaconValue).to.be.equal(123);
+          });
+        });
+        context('Beacon is not initialized', function () {
+          it('reverts', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
+            await expect(
+              dapiServer.connect(voidSignerAddressZero).readDataFeedValueWithDapiName(dapiName)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+      context('Data feed is Beacon set', function () {
+        context('Beacon set is initialized', function () {
+          it('reads Beacon set', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeaconSet(
+              airnodeAddress,
+              beaconSetTemplateIds,
+              [123, 456, 789],
+              [timestamp - 2, timestamp, timestamp + 2]
+            );
+            const beaconSetValue = await dapiServer
+              .connect(voidSignerAddressZero)
+              .readDataFeedValueWithDapiName(dapiName);
+            expect(beaconSetValue).to.be.equal(456);
+          });
+        });
+        context('Beacon set is not initialized', function () {
+          it('reverts', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            await expect(
+              dapiServer.connect(voidSignerAddressZero).readDataFeedValueWithDapiName(dapiName)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+    });
+    context('Reader is whitelisted', function () {
+      context('Data feed is Beacon', function () {
+        context('Beacon is initialized', function () {
+          it('reads Beacon', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
+            // Whitelist for the name hash, not the data feed ID
+            const dapiNameHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.defaultAbiCoder.encode(['bytes32'], [dapiName])
+            );
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(dapiNameHash, roles.randomPerson.address, true);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeacon(templateId, 123, timestamp);
+            const beaconValue = await dapiServer.connect(roles.randomPerson).readDataFeedValueWithDapiName(dapiName);
+            expect(beaconValue).to.be.equal(123);
+          });
+        });
+        context('Beacon is not initialized', function () {
+          it('reverts', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
+            // Whitelist for the name hash, not the data feed ID
+            const dapiNameHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.defaultAbiCoder.encode(['bytes32'], [dapiName])
+            );
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(dapiNameHash, roles.randomPerson.address, true);
+            await expect(
+              dapiServer.connect(roles.randomPerson).readDataFeedValueWithDapiName(dapiName)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+      context('Data feed is Beacon set', function () {
+        context('Beacon set is initialized', function () {
+          it('reads Beacon set', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            // Whitelist for the name hash, not the data feed ID
+            const dapiNameHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.defaultAbiCoder.encode(['bytes32'], [dapiName])
+            );
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(dapiNameHash, roles.randomPerson.address, true);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeaconSet(
+              airnodeAddress,
+              beaconSetTemplateIds,
+              [123, 456, 789],
+              [timestamp - 2, timestamp, timestamp + 2]
+            );
+            const beaconSetValue = await dapiServer.connect(roles.randomPerson).readDataFeedValueWithDapiName(dapiName);
+            expect(beaconSetValue).to.be.equal(456);
+          });
+        });
+        context('Beacon set is not initialized', function () {
+          it('reverts', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            // Whitelist for the name hash, not the data feed ID
+            const dapiNameHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.defaultAbiCoder.encode(['bytes32'], [dapiName])
+            );
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(dapiNameHash, roles.randomPerson.address, true);
+            await expect(
+              dapiServer.connect(roles.randomPerson).readDataFeedValueWithDapiName(dapiName)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+    });
+    context('Reader is unlimited reader', function () {
+      context('Data feed is Beacon', function () {
+        context('Beacon is initialized', function () {
+          it('reads Beacon', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeacon(templateId, 123, timestamp);
+            const beaconValue = await dapiServer.connect(roles.unlimitedReader).readDataFeedValueWithDapiName(dapiName);
+            expect(beaconValue).to.be.equal(123);
+          });
+        });
+        context('Beacon is not initialized', function () {
+          it('reverts', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
+            await expect(
+              dapiServer.connect(roles.unlimitedReader).readDataFeedValueWithDapiName(dapiName)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+      context('Data feed is Beacon set', function () {
+        context('Beacon set is initialized', function () {
+          it('reads Beacon set', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeaconSet(
+              airnodeAddress,
+              beaconSetTemplateIds,
+              [123, 456, 789],
+              [timestamp - 2, timestamp, timestamp + 2]
+            );
+            const beaconSetValue = await dapiServer
+              .connect(roles.unlimitedReader)
+              .readDataFeedValueWithDapiName(dapiName);
+            expect(beaconSetValue).to.be.equal(456);
+          });
+        });
+        context('Beacon set is not initialized', function () {
+          it('reverts', async function () {
+            const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+            await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
+            await expect(
+              dapiServer.connect(roles.unlimitedReader).readDataFeedValueWithDapiName(dapiName)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+    });
+    context('Reader is none of the above', function () {
+      it('reverts', async function () {
+        const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
+        await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
+        await expect(dapiServer.connect(roles.randomPerson).readDataFeedValueWithDapiName(dapiName)).to.be.revertedWith(
+          'Sender cannot read'
+        );
+      });
+    });
+  });
+
   describe('readerCanReadDataFeed', function () {
     context('Reader is zero address', function () {
       it('returns true for all data feeds', async function () {

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -991,7 +991,7 @@ describe('DapiServer', function () {
             context('Data is fresher than Beacon', function () {
               context('Request is regular', function () {
                 it('updates Beacon', async function () {
-                  const initialBeacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                  const initialBeacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                   expect(initialBeacon.value).to.equal(0);
                   expect(initialBeacon.timestamp).to.equal(0);
                   const requestId = await deriveRegularRequestId();
@@ -1023,14 +1023,14 @@ describe('DapiServer', function () {
                   )
                     .to.emit(dapiServer, 'UpdatedBeaconWithRrp')
                     .withArgs(beaconId, requestId, decodedData, timestamp);
-                  const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                  const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                   expect(beacon.value).to.equal(decodedData);
                   expect(beacon.timestamp).to.equal(timestamp);
                 });
               });
               context('Request is relayed', function () {
                 it('updates Beacon', async function () {
-                  const initialBeacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                  const initialBeacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                   expect(initialBeacon.value).to.equal(0);
                   expect(initialBeacon.timestamp).to.equal(0);
                   const requestId = await deriveRelayedRequestId();
@@ -1063,7 +1063,7 @@ describe('DapiServer', function () {
                   )
                     .to.emit(dapiServer, 'UpdatedBeaconWithRrp')
                     .withArgs(beaconId, requestId, decodedData, timestamp);
-                  const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                  const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                   expect(beacon.value).to.equal(decodedData);
                   expect(beacon.timestamp).to.equal(timestamp);
                 });
@@ -1114,7 +1114,7 @@ describe('DapiServer', function () {
                       { gasLimit: 500000 }
                     )
                 ).to.not.emit(dapiServer, 'UpdatedBeaconWithRrp');
-                const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                 expect(beacon.value).to.equal(123);
                 expect(beacon.timestamp).to.equal(futureTimestamp);
               });
@@ -1164,7 +1164,7 @@ describe('DapiServer', function () {
                       { gasLimit: 500000 }
                     )
                 ).to.not.emit(dapiServer, 'UpdatedBeaconWithRrp');
-                const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                 expect(beacon.value).to.equal(0);
                 expect(beacon.timestamp).to.equal(0);
               });
@@ -1212,7 +1212,7 @@ describe('DapiServer', function () {
                       { gasLimit: 500000 }
                     )
                 ).to.not.emit(dapiServer, 'UpdatedBeaconWithRrp');
-                const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                 expect(beacon.value).to.equal(0);
                 expect(beacon.timestamp).to.equal(0);
               });
@@ -1263,7 +1263,7 @@ describe('DapiServer', function () {
                   { gasLimit: 500000 }
                 )
             ).to.not.emit(dapiServer, 'UpdatedBeaconWithRrp');
-            const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+            const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
             expect(beacon.value).to.equal(0);
             expect(beacon.timestamp).to.equal(0);
           });
@@ -1312,7 +1312,7 @@ describe('DapiServer', function () {
                   { gasLimit: 500000 }
                 )
             ).to.not.emit(dapiServer, 'UpdatedBeaconWithRrp');
-            const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+            const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
             expect(beacon.value).to.equal(0);
             expect(beacon.timestamp).to.equal(0);
           });
@@ -1362,7 +1362,7 @@ describe('DapiServer', function () {
                 { gasLimit: 500000 }
               )
           ).to.not.emit(dapiServer, 'UpdatedBeaconWithRrp');
-          const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+          const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
           expect(beacon.value).to.equal(0);
           expect(beacon.timestamp).to.equal(0);
         });
@@ -1411,7 +1411,7 @@ describe('DapiServer', function () {
                 { gasLimit: 500000 }
               )
           ).to.not.emit(dapiServer, 'UpdatedBeaconWithRrp');
-          const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+          const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
           expect(beacon.value).to.equal(0);
           expect(beacon.timestamp).to.equal(0);
         });
@@ -1762,7 +1762,7 @@ describe('DapiServer', function () {
                   )
                     .to.emit(dapiServer, 'UpdatedBeaconWithPsp')
                     .withArgs(beaconId, beaconUpdateSubscriptionId, 123, timestamp);
-                  const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                  const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                   expect(beacon.value).to.equal(123);
                   expect(beacon.timestamp).to.equal(timestamp);
                 });
@@ -1816,7 +1816,7 @@ describe('DapiServer', function () {
                   )
                     .to.emit(dapiServer, 'UpdatedBeaconWithPsp')
                     .withArgs(beaconId, beaconUpdateSubscriptionRelayedId, 123, timestamp);
-                  const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+                  const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
                   expect(beacon.value).to.equal(123);
                   expect(beacon.timestamp).to.equal(timestamp);
                 });
@@ -1971,7 +1971,7 @@ describe('DapiServer', function () {
               )
                 .to.emit(dapiServer, 'UpdatedBeaconWithSignedData')
                 .withArgs(beaconId, 123, timestamp);
-              const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+              const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
               expect(beacon.value).to.equal(123);
               expect(beacon.timestamp).to.equal(timestamp);
             });
@@ -2047,7 +2047,7 @@ describe('DapiServer', function () {
             timestamp++;
             await setBeacon(beaconSetTemplateIds[ind], beaconData[ind], timestamp);
           }
-          const beaconSetInitial = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconSetId);
+          const beaconSetInitial = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconSetId);
           expect(beaconSetInitial.value).to.equal(0);
           expect(beaconSetInitial.timestamp).to.equal(0);
           expect(
@@ -2547,7 +2547,7 @@ describe('DapiServer', function () {
           )
             .to.emit(dapiServer, 'UpdatedBeaconSetWithBeacons')
             .withArgs(beaconSetId, 95, timestamp - 1);
-          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconSetId);
+          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconSetId);
           expect(beaconSet.value).to.equal(95);
           expect(beaconSet.timestamp).to.equal(timestamp - 1);
         });
@@ -2589,7 +2589,7 @@ describe('DapiServer', function () {
           )
             .to.emit(dapiServer, 'UpdatedBeaconSetWithBeacons')
             .withArgs(beaconSetId, 95, timestamp - 1);
-          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconSetId);
+          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconSetId);
           expect(beaconSet.value).to.equal(95);
           expect(beaconSet.timestamp).to.equal(timestamp - 1);
         });
@@ -2659,7 +2659,7 @@ describe('DapiServer', function () {
                     )
                       .to.emit(dapiServer, 'UpdatedBeaconSetWithSignedData')
                       .withArgs(beaconSetId, 105, timestamp);
-                    const beaconSet = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconSetId);
+                    const beaconSet = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconSetId);
                     expect(beaconSet.value).to.equal(105);
                     expect(beaconSet.timestamp).to.equal(timestamp);
                   });
@@ -2935,13 +2935,13 @@ describe('DapiServer', function () {
     });
   });
 
-  describe('readWithDataFeedId', function () {
+  describe('readDataFeedWithId', function () {
     context('Reader is zero address', function () {
       context('Data feed is Beacon', function () {
         it('reads Beacon', async function () {
           const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
           await setBeacon(templateId, 123, timestamp);
-          const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconId);
+          const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconId);
           expect(beacon.value).to.be.equal(123);
           expect(beacon.timestamp).to.be.equal(timestamp);
         });
@@ -2955,7 +2955,7 @@ describe('DapiServer', function () {
             [123, 456, 789],
             [timestamp - 2, timestamp, timestamp + 2]
           );
-          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readWithDataFeedId(beaconSetId);
+          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithId(beaconSetId);
           expect(beaconSet.value).to.be.equal(456);
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
@@ -2969,7 +2969,7 @@ describe('DapiServer', function () {
             .setIndefiniteWhitelistStatus(beaconId, roles.randomPerson.address, true);
           const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
           await setBeacon(templateId, 123, timestamp);
-          const beacon = await dapiServer.connect(roles.randomPerson).readWithDataFeedId(beaconId);
+          const beacon = await dapiServer.connect(roles.randomPerson).readDataFeedWithId(beaconId);
           expect(beacon.value).to.be.equal(123);
           expect(beacon.timestamp).to.be.equal(timestamp);
         });
@@ -2986,7 +2986,7 @@ describe('DapiServer', function () {
             [123, 456, 789],
             [timestamp - 2, timestamp, timestamp + 2]
           );
-          const beaconSet = await dapiServer.connect(roles.randomPerson).readWithDataFeedId(beaconSetId);
+          const beaconSet = await dapiServer.connect(roles.randomPerson).readDataFeedWithId(beaconSetId);
           expect(beaconSet.value).to.be.equal(456);
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
@@ -2997,7 +2997,7 @@ describe('DapiServer', function () {
         it('reads Beacon', async function () {
           const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
           await setBeacon(templateId, 123, timestamp);
-          const beacon = await dapiServer.connect(roles.unlimitedReader).readWithDataFeedId(beaconId);
+          const beacon = await dapiServer.connect(roles.unlimitedReader).readDataFeedWithId(beaconId);
           expect(beacon.value).to.be.equal(123);
           expect(beacon.timestamp).to.be.equal(timestamp);
         });
@@ -3011,7 +3011,7 @@ describe('DapiServer', function () {
             [123, 456, 789],
             [timestamp - 2, timestamp, timestamp + 2]
           );
-          const beaconSet = await dapiServer.connect(roles.unlimitedReader).readWithDataFeedId(beaconSetId);
+          const beaconSet = await dapiServer.connect(roles.unlimitedReader).readDataFeedWithId(beaconSetId);
           expect(beaconSet.value).to.be.equal(456);
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
@@ -3020,14 +3020,14 @@ describe('DapiServer', function () {
     context('Reader is none of the above', function () {
       context('Data feed is Beacon', function () {
         it('reverts', async function () {
-          await expect(dapiServer.connect(roles.randomPerson).readWithDataFeedId(beaconId)).to.be.revertedWith(
+          await expect(dapiServer.connect(roles.randomPerson).readDataFeedWithId(beaconId)).to.be.revertedWith(
             'Sender cannot read'
           );
         });
       });
       context('Data feed is Beacon set', function () {
         it('reverts', async function () {
-          await expect(dapiServer.connect(roles.randomPerson).readWithDataFeedId(beaconSetId)).to.be.revertedWith(
+          await expect(dapiServer.connect(roles.randomPerson).readDataFeedWithId(beaconSetId)).to.be.revertedWith(
             'Sender cannot read'
           );
         });
@@ -3035,7 +3035,7 @@ describe('DapiServer', function () {
     });
   });
 
-  describe('readWithDapiName', function () {
+  describe('readDataFeedWithDapiName', function () {
     context('Reader is zero address', function () {
       context('dAPI name set to Beacon', function () {
         it('reads Beacon', async function () {
@@ -3043,7 +3043,7 @@ describe('DapiServer', function () {
           await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
           const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
           await setBeacon(templateId, 123, timestamp);
-          const beacon = await dapiServer.connect(voidSignerAddressZero).readWithDapiName(dapiName);
+          const beacon = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithDapiName(dapiName);
           expect(beacon.value).to.be.equal(123);
           expect(beacon.timestamp).to.be.equal(timestamp);
         });
@@ -3059,7 +3059,7 @@ describe('DapiServer', function () {
             [123, 456, 789],
             [timestamp - 2, timestamp, timestamp + 2]
           );
-          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readWithDapiName(dapiName);
+          const beaconSet = await dapiServer.connect(voidSignerAddressZero).readDataFeedWithDapiName(dapiName);
           expect(beaconSet.value).to.be.equal(456);
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
@@ -3079,7 +3079,7 @@ describe('DapiServer', function () {
             .setIndefiniteWhitelistStatus(dapiNameHash, roles.randomPerson.address, true);
           const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
           await setBeacon(templateId, 123, timestamp);
-          const beacon = await dapiServer.connect(roles.randomPerson).readWithDapiName(dapiName);
+          const beacon = await dapiServer.connect(roles.randomPerson).readDataFeedWithDapiName(dapiName);
           expect(beacon.value).to.be.equal(123);
           expect(beacon.timestamp).to.be.equal(timestamp);
         });
@@ -3102,7 +3102,7 @@ describe('DapiServer', function () {
             [123, 456, 789],
             [timestamp - 2, timestamp, timestamp + 2]
           );
-          const beaconSet = await dapiServer.connect(roles.randomPerson).readWithDapiName(dapiName);
+          const beaconSet = await dapiServer.connect(roles.randomPerson).readDataFeedWithDapiName(dapiName);
           expect(beaconSet.value).to.be.equal(456);
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
@@ -3115,7 +3115,7 @@ describe('DapiServer', function () {
           await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
           const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
           await setBeacon(templateId, 123, timestamp);
-          const beacon = await dapiServer.connect(roles.unlimitedReader).readWithDapiName(dapiName);
+          const beacon = await dapiServer.connect(roles.unlimitedReader).readDataFeedWithDapiName(dapiName);
           expect(beacon.value).to.be.equal(123);
           expect(beacon.timestamp).to.be.equal(timestamp);
         });
@@ -3131,7 +3131,7 @@ describe('DapiServer', function () {
             [123, 456, 789],
             [timestamp - 2, timestamp, timestamp + 2]
           );
-          const beaconSet = await dapiServer.connect(roles.unlimitedReader).readWithDapiName(dapiName);
+          const beaconSet = await dapiServer.connect(roles.unlimitedReader).readDataFeedWithDapiName(dapiName);
           expect(beaconSet.value).to.be.equal(456);
           expect(beaconSet.timestamp).to.be.equal(timestamp);
         });
@@ -3142,7 +3142,7 @@ describe('DapiServer', function () {
         it('reverts', async function () {
           const dapiName = hre.ethers.utils.formatBytes32String('My beacon');
           await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconId);
-          await expect(dapiServer.connect(roles.randomPerson).readWithDapiName(dapiName)).to.be.revertedWith(
+          await expect(dapiServer.connect(roles.randomPerson).readDataFeedWithDapiName(dapiName)).to.be.revertedWith(
             'Sender cannot read'
           );
         });
@@ -3151,7 +3151,7 @@ describe('DapiServer', function () {
         it('reverts', async function () {
           const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
           await dapiServer.connect(roles.dapiNameSetter).setDapiName(dapiName, beaconSetId);
-          await expect(dapiServer.connect(roles.randomPerson).readWithDapiName(dapiName)).to.be.revertedWith(
+          await expect(dapiServer.connect(roles.randomPerson).readDataFeedWithDapiName(dapiName)).to.be.revertedWith(
             'Sender cannot read'
           );
         });

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -3035,6 +3035,151 @@ describe('DapiServer', function () {
     });
   });
 
+  describe('readDataFeedValueWithId', function () {
+    context('Reader is zero address', function () {
+      context('Data feed is Beacon', function () {
+        context('Beacon is initialized', function () {
+          it('reads Beacon', async function () {
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeacon(templateId, 123, timestamp);
+            const beaconValue = await dapiServer.connect(voidSignerAddressZero).readDataFeedValueWithId(beaconId);
+            expect(beaconValue).to.be.equal(123);
+          });
+        });
+        context('Beacon is not initialized', function () {
+          it('reverts', async function () {
+            await expect(
+              dapiServer.connect(voidSignerAddressZero).readDataFeedValueWithId(beaconId)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+      context('Data feed is Beacon set', function () {
+        context('Beacon set is initialized', function () {
+          it('reads Beacon set', async function () {
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeaconSet(
+              airnodeAddress,
+              beaconSetTemplateIds,
+              [123, 456, 789],
+              [timestamp - 2, timestamp, timestamp + 2]
+            );
+            const beaconSetValue = await dapiServer.connect(voidSignerAddressZero).readDataFeedValueWithId(beaconSetId);
+            expect(beaconSetValue).to.be.equal(456);
+          });
+        });
+        context('Beacon set is not initialized', function () {
+          it('reverts', async function () {
+            await expect(
+              dapiServer.connect(voidSignerAddressZero).readDataFeedValueWithId(beaconSetId)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+    });
+    context('Reader is whitelisted', function () {
+      context('Data feed is Beacon', function () {
+        context('Beacon is initialized', function () {
+          it('reads Beacon', async function () {
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(beaconId, roles.randomPerson.address, true);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeacon(templateId, 123, timestamp);
+            const beaconValue = await dapiServer.connect(roles.randomPerson).readDataFeedValueWithId(beaconId);
+            expect(beaconValue).to.be.equal(123);
+          });
+        });
+        context('Beacon is not initialized', function () {
+          it('reverts', async function () {
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(beaconSetId, roles.randomPerson.address, true);
+            await expect(dapiServer.connect(roles.randomPerson).readDataFeedValueWithId(beaconId)).to.be.revertedWith(
+              'Data feed does not exist'
+            );
+          });
+        });
+      });
+      context('Data feed is Beacon set', function () {
+        context('Beacon set is initialized', function () {
+          it('reads Beacon set', async function () {
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(beaconSetId, roles.randomPerson.address, true);
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeaconSet(
+              airnodeAddress,
+              beaconSetTemplateIds,
+              [123, 456, 789],
+              [timestamp - 2, timestamp, timestamp + 2]
+            );
+            const beaconSetValue = await dapiServer.connect(roles.randomPerson).readDataFeedValueWithId(beaconSetId);
+            expect(beaconSetValue).to.be.equal(456);
+          });
+        });
+        context('Beacon set is not initialized', function () {
+          it('reverts', async function () {
+            await dapiServer
+              .connect(roles.indefiniteWhitelister)
+              .setIndefiniteWhitelistStatus(beaconSetId, roles.randomPerson.address, true);
+            await expect(
+              dapiServer.connect(roles.randomPerson).readDataFeedValueWithId(beaconSetId)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+    });
+    context('Reader is unlimited reader', function () {
+      context('Data feed is Beacon', function () {
+        context('Beacon is initialized', function () {
+          it('reads Beacon', async function () {
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeacon(templateId, 123, timestamp);
+            const beaconValue = await dapiServer.connect(roles.unlimitedReader).readDataFeedValueWithId(beaconId);
+            expect(beaconValue).to.be.equal(123);
+          });
+        });
+        context('Beacon is not initialized', function () {
+          it('reverts', async function () {
+            await expect(
+              dapiServer.connect(roles.unlimitedReader).readDataFeedValueWithId(beaconId)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+      context('Data feed is Beacon set', function () {
+        context('Beacon set is initialized', function () {
+          it('reads Beacon set', async function () {
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await setBeaconSet(
+              airnodeAddress,
+              beaconSetTemplateIds,
+              [123, 456, 789],
+              [timestamp - 2, timestamp, timestamp + 2]
+            );
+            const beaconSetValue = await dapiServer.connect(roles.unlimitedReader).readDataFeedValueWithId(beaconSetId);
+            expect(beaconSetValue).to.be.equal(456);
+          });
+        });
+        context('Beacon set is not initialized', function () {
+          it('reverts', async function () {
+            await expect(
+              dapiServer.connect(roles.unlimitedReader).readDataFeedValueWithId(beaconSetId)
+            ).to.be.revertedWith('Data feed does not exist');
+          });
+        });
+      });
+    });
+    context('Reader is none of the above', function () {
+      it('reverts', async function () {
+        await expect(dapiServer.connect(roles.randomPerson).readDataFeedValueWithId(beaconId)).to.be.revertedWith(
+          'Sender cannot read'
+        );
+      });
+    });
+  });
+
   describe('readDataFeedWithDapiName', function () {
     context('Reader is zero address', function () {
       context('dAPI name set to Beacon', function () {


### PR DESCRIPTION
I have two concerns about the existing read function
- Reading it as a struct and breaking it down into the value and the timestamp may be too difficult for some users
- It will not be compatible with generic oracle interfaces that expect a single 256-bit number

This PR adds two read functions for this purpose