### PR TITLE
Carry over backwards-compatible RequesterAuthorizer

### DIFF
--- a/contracts/authorizers/RequesterAuthorizer.sol
+++ b/contracts/authorizers/RequesterAuthorizer.sol
@@ -147,6 +147,27 @@ abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
             userIsWhitelisted(deriveServiceId(airnode, endpointId), requester);
     }
 
+    /// @notice Verifies the authorization status of a request
+    /// @dev This method has redundant arguments because V0 authorizer
+    /// contracts have to have the same interface and potential authorizer
+    /// contracts may require to access the arguments that are redundant here
+    /// @param requestId Request ID
+    /// @param airnode Airnode address
+    /// @param endpointId Endpoint ID
+    /// @param sponsor Sponsor address
+    /// @param requester Requester address
+    /// @return Authorization status of the request
+    function isAuthorizedV0(
+        bytes32 requestId, // solhint-disable-line no-unused-vars
+        address airnode,
+        bytes32 endpointId,
+        address sponsor, // solhint-disable-line no-unused-vars
+        address requester
+    ) external view override returns (bool) {
+        return
+            userIsWhitelisted(deriveServiceId(airnode, endpointId), requester);
+    }
+
     /// @notice Returns the whitelist status of `requester` for the
     /// `airnode`–`endpointId` pair
     /// @param airnode Airnode address

--- a/contracts/authorizers/interfaces/IAuthorizerV0.sol
+++ b/contracts/authorizers/interfaces/IAuthorizerV0.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IAuthorizerV0 {
+    function isAuthorizedV0(
+        bytes32 requestId,
+        address airnode,
+        bytes32 endpointId,
+        address sponsor,
+        address requester
+    ) external view returns (bool);
+}

--- a/contracts/authorizers/interfaces/IRequesterAuthorizer.sol
+++ b/contracts/authorizers/interfaces/IRequesterAuthorizer.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface IRequesterAuthorizer {
+import "./IAuthorizerV0.sol";
+
+interface IRequesterAuthorizer is IAuthorizerV0 {
     event ExtendedWhitelistExpiration(
         address indexed airnode,
         bytes32 endpointId,

--- a/test/authorizers/RequesterAuthorizerWithAirnode.sol.js
+++ b/test/authorizers/RequesterAuthorizerWithAirnode.sol.js
@@ -897,4 +897,75 @@ describe('RequesterAuthorizerWithAirnode', function () {
       });
     });
   });
+
+  describe('isAuthorizedV0', function () {
+    context('Requester is whitelisted indefinitely', function () {
+      context('Requester is whitelisted temporarily', function () {
+        it('returns true', async function () {
+          await requesterAuthorizerWithAirnode
+            .connect(roles.indefiniteWhitelister)
+            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+          await requesterAuthorizerWithAirnode
+            .connect(roles.whitelistExpirationSetter)
+            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+          expect(
+            await requesterAuthorizerWithAirnode.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted temporarily', function () {
+        it('returns true', async function () {
+          await requesterAuthorizerWithAirnode
+            .connect(roles.indefiniteWhitelister)
+            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+          expect(
+            await requesterAuthorizerWithAirnode.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(true);
+        });
+      });
+    });
+    context('Requester is not whitelisted indefinitely', function () {
+      context('Requester is whitelisted temporarily', function () {
+        it('returns true', async function () {
+          await requesterAuthorizerWithAirnode
+            .connect(roles.whitelistExpirationSetter)
+            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+          expect(
+            await requesterAuthorizerWithAirnode.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted temporarily', function () {
+        it('returns false', async function () {
+          expect(
+            await requesterAuthorizerWithAirnode.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(false);
+        });
+      });
+    });
+  });
 });

--- a/test/authorizers/RequesterAuthorizerWithManager.sol.js
+++ b/test/authorizers/RequesterAuthorizerWithManager.sol.js
@@ -909,4 +909,75 @@ describe('RequesterAuthorizerWithManager', function () {
       });
     });
   });
+
+  describe('isAuthorizedV0', function () {
+    context('Requester is whitelisted indefinitely', function () {
+      context('Requester is whitelisted temporarily', function () {
+        it('returns true', async function () {
+          await requesterAuthorizerWithManager
+            .connect(roles.indefiniteWhitelister)
+            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+          await requesterAuthorizerWithManager
+            .connect(roles.whitelistExpirationSetter)
+            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+          expect(
+            await requesterAuthorizerWithManager.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted temporarily', function () {
+        it('returns true', async function () {
+          await requesterAuthorizerWithManager
+            .connect(roles.indefiniteWhitelister)
+            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+          expect(
+            await requesterAuthorizerWithManager.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(true);
+        });
+      });
+    });
+    context('Requester is not whitelisted indefinitely', function () {
+      context('Requester is whitelisted temporarily', function () {
+        it('returns true', async function () {
+          await requesterAuthorizerWithManager
+            .connect(roles.whitelistExpirationSetter)
+            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+          expect(
+            await requesterAuthorizerWithManager.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(true);
+        });
+      });
+      context('Requester is not whitelisted temporarily', function () {
+        it('returns false', async function () {
+          expect(
+            await requesterAuthorizerWithManager.isAuthorizedV0(
+              testUtils.generateRandomBytes32(),
+              airnodeAddress,
+              endpointId,
+              testUtils.generateRandomAddress(),
+              roles.requester.address
+            )
+          ).to.equal(false);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Added a backwards-compatible `isAuthorizedV0()` function to RequesterAuthorizer similar to the ones from @api3/airnode-protocol@0.6.0. I'm planning to do a release after merging this.