### PR TITLE
Have DapiServer inherit ExtendedMulticall

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
+import "../utils/ExtendedMulticall.sol";
 import "../whitelist/WhitelistWithManager.sol";
 import "../protocol/AirnodeRequester.sol";
 import "./Median.sol";
@@ -30,6 +31,7 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 /// checked because this is a purely keeper job that does not require off-chain
 /// data. Similar to Beacon updates, any Beacon set update is welcome.
 contract DapiServer is
+    ExtendedMulticall,
     WhitelistWithManager,
     AirnodeRequester,
     Median,


### PR DESCRIPTION
We need to be able to read multiple Beacons/Beacon sets and the block number at that time with a single static call, which is why ExtendedMulticall is needed in DapiServer.