### PR TITLE
Have data feed values be unsigned

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -40,10 +40,10 @@ contract DapiServer is
     using ECDSA for bytes32;
 
     // Airnodes serve their fulfillment data along with timestamps. This
-    // contract casts the reported data to `int224` and the timestamp to
+    // contract casts the reported data to `uint224` and the timestamp to
     // `uint32`, which works until year 2106.
     struct DataFeed {
-        int224 value;
+        uint224 value;
         uint32 timestamp;
     }
 
@@ -145,8 +145,8 @@ contract DapiServer is
     /// `setRrpSponsorshipStatus()`), the sponsor must also give update request
     /// permission to the sender (by calling
     /// `setRrpBeaconUpdatePermissionStatus()`) before this method is called.
-    /// The template must specify a single point of data of type `int256` to be
-    /// returned and for it to be small enough to be castable to `int224`
+    /// The template must specify a single point of data of type `uint256` to be
+    /// returned and for it to be small enough to be castable to `uint224`
     /// because this is what `fulfillRrpBeaconUpdate()` expects.
     /// @param airnode Airnode address
     /// @param templateId Template ID
@@ -223,7 +223,7 @@ contract DapiServer is
     /// AirnodeProtocol to fulfill the request
     /// @param requestId Request ID
     /// @param timestamp Timestamp used in the signature
-    /// @param data Fulfillment data (an `int256` encoded in contract ABI)
+    /// @param data Fulfillment data (a `uint256` encoded in contract ABI)
     function fulfillRrpBeaconUpdate(
         bytes32 requestId,
         uint256 timestamp,
@@ -231,7 +231,7 @@ contract DapiServer is
     ) external override onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         bytes32 beaconId = requestIdToBeaconId[requestId];
         delete requestIdToBeaconId[requestId];
-        int256 decodedData = processBeaconUpdate(beaconId, timestamp, data);
+        uint256 decodedData = processBeaconUpdate(beaconId, timestamp, data);
         emit UpdatedBeaconWithRrp(beaconId, requestId, decodedData, timestamp);
     }
 
@@ -298,7 +298,7 @@ contract DapiServer is
     /// @dev `conditionParameters` are specified within the `conditions` field
     /// of a Subscription
     /// @param subscriptionId Subscription ID
-    /// @param data Fulfillment data (an `int256` encoded in contract ABI)
+    /// @param data Fulfillment data (a `uint256` encoded in contract ABI)
     /// @param conditionParameters Subscription condition parameters (a
     /// `uint256` encoded in contract ABI)
     /// @return If the Beacon update subscription should be fulfilled
@@ -330,8 +330,7 @@ contract DapiServer is
     /// @param relayer Relayer address
     /// @param sponsor Sponsor address
     /// @param timestamp Timestamp used in the signature
-    /// @param data Fulfillment data (a single `int256` encoded in contract
-    /// ABI)
+    /// @param data Fulfillment data (a `uint256` encoded in contract ABI)
     /// @param signature Subscription ID, timestamp, sponsor wallet address
     /// (and fulfillment data if the relayer is not the Airnode) signed by the
     /// Airnode wallet
@@ -376,11 +375,11 @@ contract DapiServer is
         bytes32 beaconId = subscriptionIdToBeaconId[subscriptionId];
         // Beacon ID is guaranteed to not be zero because the subscription is
         // registered
-        int256 decodedData = processBeaconUpdate(beaconId, timestamp, data);
+        uint256 decodedData = processBeaconUpdate(beaconId, timestamp, data);
         emit UpdatedBeaconWithPsp(
             beaconId,
             subscriptionId,
-            int224(decodedData),
+            uint224(decodedData),
             uint32(timestamp)
         );
     }
@@ -392,7 +391,7 @@ contract DapiServer is
     /// @param airnode Airnode address
     /// @param templateId Template ID
     /// @param timestamp Timestamp used in the signature
-    /// @param data Response data (an `int256` encoded in contract ABI)
+    /// @param data Response data (a `uint256` encoded in contract ABI)
     /// @param signature Template ID, a timestamp and the response data signed
     /// by the Airnode address
     function updateBeaconWithSignedData(
@@ -410,7 +409,7 @@ contract DapiServer is
             "Signature mismatch"
         );
         bytes32 beaconId = deriveBeaconId(airnode, templateId);
-        int256 decodedData = processBeaconUpdate(beaconId, timestamp, data);
+        uint256 decodedData = processBeaconUpdate(beaconId, timestamp, data);
         emit UpdatedBeaconWithSignedData(beaconId, decodedData, timestamp);
     }
 
@@ -427,7 +426,7 @@ contract DapiServer is
         override
         returns (bytes32 beaconSetId)
     {
-        (int224 updatedValue, uint32 updatedTimestamp) = aggregateBeacons(
+        (uint224 updatedValue, uint32 updatedTimestamp) = aggregateBeacons(
             beaconIds
         );
         beaconSetId = deriveBeaconSetId(beaconIds);
@@ -468,7 +467,7 @@ contract DapiServer is
             keccak256(abi.encode(beaconIds)) == keccak256(data),
             "Data length not correct"
         );
-        (int224 updatedValue, uint32 updatedTimestamp) = aggregateBeacons(
+        (uint224 updatedValue, uint32 updatedTimestamp) = aggregateBeacons(
             beaconIds
         );
         return
@@ -498,7 +497,7 @@ contract DapiServer is
     /// @param relayer Relayer address
     /// @param sponsor Sponsor address
     /// @param timestamp Timestamp used in the signature
-    /// @param data Fulfillment data (an `int256` encoded in contract ABI)
+    /// @param data Fulfillment data (a `uint256` encoded in contract ABI)
     /// @param signature Subscription ID, timestamp, sponsor wallet address
     /// (and fulfillment data if the relayer is not the Airnode) signed by the
     /// Airnode wallet
@@ -526,7 +525,7 @@ contract DapiServer is
     /// @param airnodes Airnode addresses
     /// @param templateIds Template IDs
     /// @param timestamps Timestamps used in the signatures
-    /// @param data Response data (an `int256` encoded in contract ABI per
+    /// @param data Response data (a `uint256` encoded in contract ABI per
     /// Beacon)
     /// @param signatures Template ID, a timestamp and the response data signed
     /// by the respective Airnode address per Beacon
@@ -548,7 +547,7 @@ contract DapiServer is
         );
         require(beaconCount > 1, "Specified less than two Beacons");
         bytes32[] memory beaconIds = new bytes32[](beaconCount);
-        int256[] memory values = new int256[](beaconCount);
+        uint256[] memory values = new uint256[](beaconCount);
         uint256 accumulatedTimestamp = 0;
         for (uint256 ind = 0; ind < beaconCount; ind++) {
             if (signatures[ind].length != 0) {
@@ -589,7 +588,7 @@ contract DapiServer is
             updatedTimestamp >= dataFeeds[beaconSetId].timestamp,
             "Updated value outdated"
         );
-        int224 updatedValue = int224(median(values));
+        uint224 updatedValue = uint224(median(values));
         dataFeeds[beaconSetId] = DataFeed({
             value: updatedValue,
             timestamp: updatedTimestamp
@@ -647,7 +646,7 @@ contract DapiServer is
         external
         view
         override
-        returns (int224 value, uint32 timestamp)
+        returns (uint224 value, uint32 timestamp)
     {
         DataFeed storage dataFeed = dataFeeds[dataFeedId];
         return (dataFeed.value, dataFeed.timestamp);
@@ -660,7 +659,7 @@ contract DapiServer is
         external
         view
         override
-        returns (int224 value)
+        returns (uint224 value)
     {
         DataFeed storage dataFeed = dataFeeds[dataFeedId];
         require(dataFeed.timestamp != 0, "Data feed does not exist");
@@ -675,7 +674,7 @@ contract DapiServer is
         external
         view
         override
-        returns (int224 value, uint32 timestamp)
+        returns (uint224 value, uint32 timestamp)
     {
         bytes32 dataFeedId = dapiNameHashToDataFeedId[
             keccak256(abi.encodePacked(dapiName))
@@ -692,7 +691,7 @@ contract DapiServer is
         external
         view
         override
-        returns (int224 value)
+        returns (uint224 value)
     {
         bytes32 dapiNameHash = keccak256(abi.encodePacked(dapiName));
         DataFeed storage dataFeed = dataFeeds[
@@ -713,18 +712,18 @@ contract DapiServer is
         public
         view
         override
-        returns (int224 value, uint32 timestamp)
+        returns (uint224 value, uint32 timestamp)
     {
         uint256 beaconCount = beaconIds.length;
         require(beaconCount > 1, "Specified less than two Beacons");
-        int256[] memory values = new int256[](beaconCount);
+        uint256[] memory values = new uint256[](beaconCount);
         uint256 accumulatedTimestamp = 0;
         for (uint256 ind = 0; ind < beaconCount; ind++) {
             DataFeed storage dataFeed = dataFeeds[beaconIds[ind]];
             values[ind] = dataFeed.value;
             accumulatedTimestamp += dataFeed.timestamp;
         }
-        value = int224(median(values));
+        value = uint224(median(values));
         timestamp = uint32(accumulatedTimestamp / beaconCount);
     }
 
@@ -759,13 +758,13 @@ contract DapiServer is
     /// @notice Called privately to process the Beacon update
     /// @param beaconId Beacon ID
     /// @param timestamp Timestamp used in the signature
-    /// @param data Fulfillment data (an `int256` encoded in contract ABI)
+    /// @param data Fulfillment data (a `uint256` encoded in contract ABI)
     /// @return updatedBeaconValue Updated Beacon value
     function processBeaconUpdate(
         bytes32 beaconId,
         uint256 timestamp,
         bytes calldata data
-    ) private returns (int256 updatedBeaconValue) {
+    ) private returns (uint256 updatedBeaconValue) {
         updatedBeaconValue = decodeFulfillmentData(data);
         require(
             timestamp > dataFeeds[beaconId].timestamp,
@@ -774,26 +773,23 @@ contract DapiServer is
         // Timestamp validity is already checked by `onlyValidTimestamp`, which
         // means it will be small enough to be typecast into `uint32`
         dataFeeds[beaconId] = DataFeed({
-            value: int224(updatedBeaconValue),
+            value: uint224(updatedBeaconValue),
             timestamp: uint32(timestamp)
         });
     }
 
     /// @notice Called privately to decode the fulfillment data
-    /// @param data Fulfillment data (an `int256` encoded in contract ABI)
+    /// @param data Fulfillment data (a `uint256` encoded in contract ABI)
     /// @return decodedData Decoded fulfillment data
     function decodeFulfillmentData(bytes memory data)
         private
         pure
-        returns (int224)
+        returns (uint224)
     {
         require(data.length == 32, "Data length not correct");
-        int256 decodedData = abi.decode(data, (int256));
-        require(
-            decodedData >= type(int224).min && decodedData <= type(int224).max,
-            "Value typecasting error"
-        );
-        return int224(decodedData);
+        uint256 decodedData = abi.decode(data, (uint256));
+        require(decodedData <= type(uint224).max, "Value typecasting error");
+        return uint224(decodedData);
     }
 
     /// @notice Called privately to check the update condition
@@ -805,7 +801,7 @@ contract DapiServer is
     /// @return If update should be executed
     function checkUpdateCondition(
         bytes32 dataFeedId,
-        int224 updatedValue,
+        uint224 updatedValue,
         uint32 updatedTimestamp,
         bytes calldata conditionParameters
     ) private view returns (bool) {
@@ -835,20 +831,20 @@ contract DapiServer is
     /// @param updatedValue Updated value
     /// @return updateInPercentage Update in percentage
     function calculateUpdateInPercentage(
-        int224 initialValue,
-        int224 updatedValue
+        uint224 initialValue,
+        uint224 updatedValue
     ) private pure returns (uint256 updateInPercentage) {
-        int256 delta = int256(updatedValue) - int256(initialValue);
-        uint256 absoluteDelta = delta > 0 ? uint256(delta) : uint256(-delta);
-        uint256 absoluteInitialValue = initialValue > 0
-            ? uint256(int256(initialValue))
-            : uint256(-int256(initialValue));
-        // Avoid division by 0
-        if (absoluteInitialValue == 0) {
-            absoluteInitialValue = 1;
+        uint256 absoluteDelta = updatedValue > initialValue
+            ? updatedValue - initialValue
+            : initialValue - updatedValue;
+        if (initialValue != 0) {
+            updateInPercentage =
+                (absoluteDelta * HUNDRED_PERCENT) /
+                initialValue;
+        } else if (absoluteDelta == 0) {
+            updateInPercentage = 0;
+        } else {
+            updateInPercentage = type(uint256).max;
         }
-        updateInPercentage =
-            (absoluteDelta * HUNDRED_PERCENT) /
-            absoluteInitialValue;
     }
 }

--- a/contracts/dapis/Median.sol
+++ b/contracts/dapis/Median.sol
@@ -14,7 +14,7 @@ contract Median is Sort, Quickselect {
     /// quickselect for longer arrays for gas cost efficiency
     /// @param array Array whose median is to be calculated
     /// @return Median of the array
-    function median(int256[] memory array) internal pure returns (int256) {
+    function median(uint256[] memory array) internal pure returns (uint256) {
         uint256 arrayLength = array.length;
         if (arrayLength <= MAX_SORT_LENGTH) {
             sort(array);

--- a/contracts/dapis/QuickSelect.sol
+++ b/contracts/dapis/QuickSelect.sol
@@ -10,7 +10,7 @@ contract Quickselect {
     /// @param array Array in which k-th largest element will be searched
     /// @param k K
     /// @return indK Index of the k-th largest element
-    function quickselectK(int256[] memory array, uint256 k)
+    function quickselectK(uint256[] memory array, uint256 k)
         internal
         pure
         returns (uint256 indK)
@@ -25,7 +25,7 @@ contract Quickselect {
     /// @param k K
     /// @return indK Index of the k-th largest element
     /// @return indKPlusOne Index of the (k+1)-th largest element
-    function quickselectKPlusOne(int256[] memory array, uint256 k)
+    function quickselectKPlusOne(uint256[] memory array, uint256 k)
         internal
         pure
         returns (uint256 indK, uint256 indKPlusOne)
@@ -49,7 +49,7 @@ contract Quickselect {
     /// @return indKPlusOne Index of the (k+1)-th largest element (only set if
     /// `selectKPlusOne` is `true`)
     function quickselect(
-        int256[] memory array,
+        uint256[] memory array,
         uint256 lo,
         uint256 hi,
         uint256 k,
@@ -88,14 +88,14 @@ contract Quickselect {
     /// partitioned
     /// @return pivotInd Pivot index
     function partition(
-        int256[] memory array,
+        uint256[] memory array,
         uint256 lo,
         uint256 hi
     ) private pure returns (uint256 pivotInd) {
         if (lo == hi) {
             return lo;
         }
-        int256 pivot = array[lo];
+        uint256 pivot = array[lo];
         uint256 i = lo;
         pivotInd = hi + 1;
         while (true) {

--- a/contracts/dapis/Sort.sol
+++ b/contracts/dapis/Sort.sol
@@ -10,7 +10,7 @@ contract Sort {
 
     /// @notice Sorts the array
     /// @param array Array to be sorted
-    function sort(int256[] memory array) internal pure {
+    function sort(uint256[] memory array) internal pure {
         uint256 arrayLength = array.length;
         require(arrayLength <= MAX_SORT_LENGTH, "Array too long to sort");
         // Do a binary search
@@ -149,7 +149,7 @@ contract Sort {
     /// @param ind1 Index of the first element
     /// @param ind2 Index of the second element
     function swapIfFirstIsLarger(
-        int256[] memory array,
+        uint256[] memory array,
         uint256 ind1,
         uint256 ind2
     ) private pure {

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -33,7 +33,7 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
     event UpdatedBeaconWithRrp(
         bytes32 indexed beaconId,
         bytes32 requestId,
-        int256 value,
+        uint256 value,
         uint256 timestamp
     );
 
@@ -52,25 +52,25 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
     event UpdatedBeaconWithPsp(
         bytes32 indexed beaconId,
         bytes32 subscriptionId,
-        int224 value,
+        uint224 value,
         uint32 timestamp
     );
 
     event UpdatedBeaconWithSignedData(
         bytes32 indexed beaconId,
-        int256 value,
+        uint256 value,
         uint256 timestamp
     );
 
     event UpdatedBeaconSetWithBeacons(
         bytes32 indexed beaconSetId,
-        int224 value,
+        uint224 value,
         uint32 timestamp
     );
 
     event UpdatedBeaconSetWithSignedData(
         bytes32 indexed dapiId,
-        int224 value,
+        uint224 value,
         uint32 timestamp
     );
 
@@ -174,27 +174,27 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
     function readDataFeedWithId(bytes32 dataFeedId)
         external
         view
-        returns (int224 value, uint32 timestamp);
+        returns (uint224 value, uint32 timestamp);
 
     function readDataFeedValueWithId(bytes32 dataFeedId)
         external
         view
-        returns (int224 value);
+        returns (uint224 value);
 
     function readDataFeedWithDapiName(bytes32 dapiName)
         external
         view
-        returns (int224 value, uint32 timestamp);
+        returns (uint224 value, uint32 timestamp);
 
     function readDataFeedValueWithDapiName(bytes32 dapiName)
         external
         view
-        returns (int224 value);
+        returns (uint224 value);
 
     function aggregateBeacons(bytes32[] memory beaconIds)
         external
         view
-        returns (int224 value, uint32 timestamp);
+        returns (uint224 value, uint32 timestamp);
 
     function deriveBeaconId(address airnode, bytes32 templateId)
         external

--- a/contracts/dapis/mock/MockDapiReader.sol
+++ b/contracts/dapis/mock/MockDapiReader.sol
@@ -13,7 +13,7 @@ contract MockDapiReader is DapiReader {
     function exposedReadWithDataFeedId(bytes32 dataFeedId)
         external
         view
-        returns (int224 value, uint32 timestamp)
+        returns (uint224 value, uint32 timestamp)
     {
         return IDapiServer(dapiServer).readDataFeedWithId(dataFeedId);
     }
@@ -21,7 +21,7 @@ contract MockDapiReader is DapiReader {
     function exposedReadWithDapiName(bytes32 dapiName)
         external
         view
-        returns (int224 value, uint32 timestamp)
+        returns (uint224 value, uint32 timestamp)
     {
         return IDapiServer(dapiServer).readDataFeedWithDapiName(dapiName);
     }

--- a/contracts/dapis/mock/MockMedian.sol
+++ b/contracts/dapis/mock/MockMedian.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.9;
 import "../Median.sol";
 
 contract MockMedian is Median {
-    function exposedMedian(int256[] memory array)
+    function exposedMedian(uint256[] memory array)
         external
         pure
-        returns (int256)
+        returns (uint256)
     {
         return median(array);
     }

--- a/contracts/dapis/mock/MockSort.sol
+++ b/contracts/dapis/mock/MockSort.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.9;
 import "../Median.sol";
 
 contract MockSort is Sort {
-    function exposedSort(int256[] memory array)
+    function exposedSort(uint256[] memory array)
         external
         pure
-        returns (int256[] memory)
+        returns (uint256[] memory)
     {
         sort(array);
         return array;

--- a/extended-test/dapis/Median.sol.js
+++ b/extended-test/dapis/Median.sol.js
@@ -18,7 +18,7 @@ describe('Median', function () {
       it('computes median of randomly shuffled arrays', async function () {
         for (let arrayLength = 1; arrayLength <= 21; arrayLength++) {
           for (let iterationCount = 0; iterationCount <= 10; iterationCount++) {
-            const array = Array.from(Array(arrayLength), (_, i) => i - Math.floor(arrayLength / 2));
+            const array = Array.from(Array(arrayLength).keys());
             const shuffledArray = array
               .map((value) => ({ value, sort: Math.random() }))
               .sort((a, b) => a.sort - b.sort)

--- a/extended-test/dapis/Sort.sol.js
+++ b/extended-test/dapis/Sort.sol.js
@@ -6,7 +6,7 @@ describe('Sort', function () {
 
   // Adapted from https://stackoverflow.com/a/37580979/14558682
   async function testSortWithAllPermutations(arrayLength) {
-    const array = Array.from(Array(arrayLength), (_, i) => i - Math.floor(arrayLength / 2));
+    const array = Array.from(Array(arrayLength).keys());
     let length = array.length,
       c = new Array(length).fill(0),
       i = 1,


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode-protocol-v1/issues/37

This is obviously superior for price data feeds, whose values are expected to be positive. Also, the signed implementation with %-based deviation thresholds simply didn't work. For example, consider a temperature data feed in Celsius. Whenever the temperature moves between -1 and +1, the data feed is going to update for any reasonable deviation threshold (i.e., that is smaller than 100%), which can't be right.

In the new scheme, the template includes some post-processing (most likely using [airnode-plug](https://github.com/api3dao/airnode/issues/1224)) that will convert the data into a positive number where the deviation threshold makes sense. For example, in the temperature case, we can have airnode-plug specify [273](https://en.wikipedia.org/wiki/Absolute_zero) to be added to the temperature (`.add(273)`) before writing it to the chain. Then, with a deviation threshold of 1%, the data feed will update every 2.73 degree update around 0 degrees Celsius. The user of this data feed will need to subtract 273 before using it in their contract (which needs to be documented off-chain, similar to how we document that we use 18 decimals for our price data feeds).