### PR TITLE
Blanket authorization

### DIFF
--- a/contracts/authorizers/RequesterAuthorizer.sol
+++ b/contracts/authorizers/RequesterAuthorizer.sol
@@ -6,6 +6,9 @@ import "./interfaces/IRequesterAuthorizer.sol";
 
 /// @title Abstract contract to be inherited by Authorizer contracts that
 /// temporarily or permanently whitelist requesters for Airnode–endpoint pairs
+/// or Airnodes
+/// @dev An authorization for an Airnode with endpoint ID `bytes32(0)`
+/// represents a blanket authorization across all endpoints of the Airnode
 abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
     /// @notice Extends the expiration of the temporary whitelist of
     /// `requester` for the `airnode`–`endpointId` pair and emits an event
@@ -142,8 +145,12 @@ abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
         address airnode,
         bytes32 endpointId,
         address requester
-    ) external view override returns (bool) {
+    ) public view override returns (bool) {
         return
+            userIsWhitelisted(
+                deriveServiceId(airnode, bytes32(0)),
+                requester
+            ) ||
             userIsWhitelisted(deriveServiceId(airnode, endpointId), requester);
     }
 
@@ -164,8 +171,7 @@ abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
         address sponsor, // solhint-disable-line no-unused-vars
         address requester
     ) external view override returns (bool) {
-        return
-            userIsWhitelisted(deriveServiceId(airnode, endpointId), requester);
+        return isAuthorized(airnode, endpointId, requester);
     }
 
     /// @notice Returns the whitelist status of `requester` for the

--- a/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
@@ -6,7 +6,7 @@ import "./RequesterAuthorizer.sol";
 import "./interfaces/IRequesterAuthorizerWithAirnode.sol";
 
 /// @title Authorizer contract that Airnode operators can use to temporarily or
-/// indefinitely whitelist requesters for Airnode–endpoint pairs
+/// indefinitely whitelist requesters for Airnode–endpoint pairs or Airnodes
 contract RequesterAuthorizerWithAirnode is
     WhitelistRolesWithAirnode,
     RequesterAuthorizer,

--- a/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
@@ -22,8 +22,8 @@ contract RequesterAuthorizerWithAirnode is
     {}
 
     /// @notice Extends the expiration of the temporary whitelist of
-    /// `requester` for the `airnode`–`endpointId` pair if the sender has the
-    /// whitelist expiration extender role
+    /// `requester` for the `airnode`–`endpointId` pair if the sender is
+    /// allowed to extend whitelist expiration
     /// @param airnode Airnode address
     /// @param endpointId Endpoint ID
     /// @param requester Requester address
@@ -48,8 +48,8 @@ contract RequesterAuthorizerWithAirnode is
     }
 
     /// @notice Sets the expiration of the temporary whitelist of `requester`
-    /// for the `airnode`–`endpointId` pair if the sender has the whitelist
-    /// expiration setter role
+    /// for the `airnode`–`endpointId` pair if the sender is allowed to set
+    /// expiration
     /// @dev Unlike `extendWhitelistExpiration()`, this can hasten expiration
     /// @param airnode Airnode address
     /// @param endpointId Endpoint ID
@@ -75,8 +75,8 @@ contract RequesterAuthorizerWithAirnode is
     }
 
     /// @notice Sets the indefinite whitelist status of `requester` for the
-    /// `airnode`–`endpointId` pair if the sender has the indefinite
-    /// whitelister role
+    /// `airnode`–`endpointId` pair if the sender is allowed to whitelist
+    /// indefinitely
     /// @param airnode Airnode address
     /// @param endpointId Endpoint ID
     /// @param requester Requester address

--- a/contracts/authorizers/RequesterAuthorizerWithManager.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithManager.sol
@@ -28,8 +28,8 @@ contract RequesterAuthorizerWithManager is
     {}
 
     /// @notice Extends the expiration of the temporary whitelist of
-    /// `requester` for the `airnode`–`endpointId` pair if the sender has the
-    /// whitelist expiration extender role
+    /// `requester` for the `airnode`–`endpointId` pair if the sender is
+    /// allowed to extend whitelist expiration
     /// @param airnode Airnode address
     /// @param endpointId Endpoint ID
     /// @param requester Requester address
@@ -54,8 +54,8 @@ contract RequesterAuthorizerWithManager is
     }
 
     /// @notice Sets the expiration of the temporary whitelist of `requester`
-    /// for the `airnode`–`endpointId` pair if the sender has the whitelist
-    /// expiration setter role
+    /// for the `airnode`–`endpointId` pair if the sender is allowed to set
+    /// expiration
     /// @dev Unlike `extendWhitelistExpiration()`, this can hasten expiration
     /// @param airnode Airnode address
     /// @param endpointId Endpoint ID
@@ -81,8 +81,8 @@ contract RequesterAuthorizerWithManager is
     }
 
     /// @notice Sets the indefinite whitelist status of `requester` for the
-    /// `airnode`–`endpointId` pair if the sender has the indefinite
-    /// whitelister role
+    /// `airnode`–`endpointId` pair if the sender is allowed to whitelist
+    /// indefinitely
     /// @param airnode Airnode address
     /// @param endpointId Endpoint ID
     /// @param requester Requester address

--- a/contracts/authorizers/RequesterAuthorizerWithManager.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithManager.sol
@@ -6,7 +6,7 @@ import "./RequesterAuthorizer.sol";
 import "./interfaces/IRequesterAuthorizerWithManager.sol";
 
 /// @title Authorizer contract that a manager can use to temporarily or
-/// indefinitely whitelist requesters for Airnode–endpoint pairs
+/// indefinitely whitelist requesters for Airnode–endpoint pairs or Airnodes
 contract RequesterAuthorizerWithManager is
     WhitelistRolesWithManager,
     RequesterAuthorizer,

--- a/test/authorizers/RequesterAuthorizerWithAirnode.sol.js
+++ b/test/authorizers/RequesterAuthorizerWithAirnode.sol.js
@@ -852,43 +852,200 @@ describe('RequesterAuthorizerWithAirnode', function () {
   });
 
   describe('isAuthorized', function () {
-    context('Requester is whitelisted indefinitely', function () {
-      context('Requester is whitelisted temporarily', function () {
-        it('returns true', async function () {
-          await requesterAuthorizerWithAirnode
-            .connect(roles.indefiniteWhitelister)
-            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
-          await requesterAuthorizerWithAirnode
-            .connect(roles.whitelistExpirationSetter)
-            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
-          expect(
-            await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
-          ).to.equal(true);
+    context('Endpoint whitelisting is used when applicable', function () {
+      context('Blanket whitelisting is used when applicable', function () {
+        context('Requester is whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+        });
+        context('Requester is not whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns false', async function () {
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(false);
+            });
+          });
         });
       });
-      context('Requester is not whitelisted temporarily', function () {
-        it('returns true', async function () {
-          await requesterAuthorizerWithAirnode
-            .connect(roles.indefiniteWhitelister)
-            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
-          expect(
-            await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
-          ).to.equal(true);
+      context('Blanket whitelisting is not used', function () {
+        context('Requester is whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+        });
+        context('Requester is not whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns false', async function () {
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(false);
+            });
+          });
         });
       });
     });
-    context('Requester is not whitelisted indefinitely', function () {
-      context('Requester is whitelisted temporarily', function () {
-        it('returns true', async function () {
-          await requesterAuthorizerWithAirnode
-            .connect(roles.whitelistExpirationSetter)
-            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
-          expect(
-            await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
-          ).to.equal(true);
+    context('Endpoint whitelisting is not used', function () {
+      context('Blanket whitelisting is used when applicable', function () {
+        context('Requester is whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+        });
+        context('Requester is not whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns false', async function () {
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
+              ).to.equal(false);
+            });
+          });
         });
       });
-      context('Requester is not whitelisted temporarily', function () {
+      context('Blanket whitelisting is not used', function () {
         it('returns false', async function () {
           expect(
             await requesterAuthorizerWithAirnode.isAuthorized(airnodeAddress, endpointId, roles.requester.address)
@@ -899,61 +1056,272 @@ describe('RequesterAuthorizerWithAirnode', function () {
   });
 
   describe('isAuthorizedV0', function () {
-    context('Requester is whitelisted indefinitely', function () {
-      context('Requester is whitelisted temporarily', function () {
-        it('returns true', async function () {
-          await requesterAuthorizerWithAirnode
-            .connect(roles.indefiniteWhitelister)
-            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
-          await requesterAuthorizerWithAirnode
-            .connect(roles.whitelistExpirationSetter)
-            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
-          expect(
-            await requesterAuthorizerWithAirnode.isAuthorizedV0(
-              testUtils.generateRandomBytes32(),
-              airnodeAddress,
-              endpointId,
-              testUtils.generateRandomAddress(),
-              roles.requester.address
-            )
-          ).to.equal(true);
+    context('Endpoint whitelisting is used when applicable', function () {
+      context('Blanket whitelisting is used when applicable', function () {
+        context('Requester is whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+        });
+        context('Requester is not whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns false', async function () {
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(false);
+            });
+          });
         });
       });
-      context('Requester is not whitelisted temporarily', function () {
-        it('returns true', async function () {
-          await requesterAuthorizerWithAirnode
-            .connect(roles.indefiniteWhitelister)
-            .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
-          expect(
-            await requesterAuthorizerWithAirnode.isAuthorizedV0(
-              testUtils.generateRandomBytes32(),
-              airnodeAddress,
-              endpointId,
-              testUtils.generateRandomAddress(),
-              roles.requester.address
-            )
-          ).to.equal(true);
+      context('Blanket whitelisting is not used', function () {
+        context('Requester is whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(airnodeAddress, endpointId, roles.requester.address, true);
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+        });
+        context('Requester is not whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns false', async function () {
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(false);
+            });
+          });
         });
       });
     });
-    context('Requester is not whitelisted indefinitely', function () {
-      context('Requester is whitelisted temporarily', function () {
-        it('returns true', async function () {
-          await requesterAuthorizerWithAirnode
-            .connect(roles.whitelistExpirationSetter)
-            .setWhitelistExpiration(airnodeAddress, endpointId, roles.requester.address, 2000000000);
-          expect(
-            await requesterAuthorizerWithAirnode.isAuthorizedV0(
-              testUtils.generateRandomBytes32(),
-              airnodeAddress,
-              endpointId,
-              testUtils.generateRandomAddress(),
-              roles.requester.address
-            )
-          ).to.equal(true);
+    context('Endpoint whitelisting is not used', function () {
+      context('Blanket whitelisting is used when applicable', function () {
+        context('Requester is whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.indefiniteWhitelister)
+                .setIndefiniteWhitelistStatus(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  true
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+        });
+        context('Requester is not whitelisted indefinitely', function () {
+          context('Requester is whitelisted temporarily', function () {
+            it('returns true', async function () {
+              await requesterAuthorizerWithAirnode
+                .connect(roles.whitelistExpirationSetter)
+                .setWhitelistExpiration(
+                  airnodeAddress,
+                  hre.ethers.constants.HashZero,
+                  roles.requester.address,
+                  2000000000
+                );
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(true);
+            });
+          });
+          context('Requester is not whitelisted temporarily', function () {
+            it('returns false', async function () {
+              expect(
+                await requesterAuthorizerWithAirnode.isAuthorizedV0(
+                  testUtils.generateRandomBytes32(),
+                  airnodeAddress,
+                  endpointId,
+                  testUtils.generateRandomAddress(),
+                  roles.requester.address
+                )
+              ).to.equal(false);
+            });
+          });
         });
       });
-      context('Requester is not whitelisted temporarily', function () {
+      context('Blanket whitelisting is not used', function () {
         it('returns false', async function () {
           expect(
             await requesterAuthorizerWithAirnode.isAuthorizedV0(


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode-protocol-v1/issues/47

The current implementation of RequesterAuthorizers allow endpoint with ID 0 to be whitelisted to support https://github.com/api3dao/airnode/issues/1527 However, during our research, we realized that using the endpoint with ID 0 for this purpose is not appropriate and that should be a proper endpoint with an ID. Then, instead of removing the endpoint-specific authorization functionality, I used authorizations with endpoint ID 0 as a blanket authorization across all endpoints of the Airnode.

Although the current ERC20-based monetization contracts can be updated according to this, I didn't bother because they have gone obsolete https://github.com/api3dao/airnode-protocol-v1/issues/45