### PR TITLE
Use ERC2771 to enable a limited subset of meta-txes for Authorizers and Allocators

### DIFF
--- a/contracts/allocators/AllocatorWithAirnode.sol
+++ b/contracts/allocators/AllocatorWithAirnode.sol
@@ -15,14 +15,18 @@ contract AllocatorWithAirnode is
 {
     /// @param _accessControlRegistry AccessControlRegistry contract address
     /// @param _adminRoleDescription Admin role description
+    /// @param _trustedForwarder Trusted forwarder that verifies and executes
+    /// signed meta-calls
     constructor(
         address _accessControlRegistry,
-        string memory _adminRoleDescription
+        string memory _adminRoleDescription,
+        address _trustedForwarder
     )
         AccessControlRegistryAdminned(
             _accessControlRegistry,
             _adminRoleDescription
         )
+        Allocator(_trustedForwarder)
     {}
 
     /// @notice Sets a slot with the given parameters
@@ -38,7 +42,7 @@ contract AllocatorWithAirnode is
         uint64 expirationTimestamp
     ) external override {
         require(
-            hasSlotSetterRoleOrIsAirnode(airnode, msg.sender),
+            hasSlotSetterRoleOrIsAirnode(airnode, _msgSender()),
             "Sender cannot set slot"
         );
         _setSlot(airnode, slotIndex, subscriptionId, expirationTimestamp);

--- a/contracts/allocators/AllocatorWithManager.sol
+++ b/contracts/allocators/AllocatorWithManager.sol
@@ -21,16 +21,20 @@ contract AllocatorWithManager is
     /// @param _accessControlRegistry AccessControlRegistry contract address
     /// @param _adminRoleDescription Admin role description
     /// @param _manager Manager address
+    /// @param _trustedForwarder Trusted forwarder that verifies and executes
+    /// signed meta-calls
     constructor(
         address _accessControlRegistry,
         string memory _adminRoleDescription,
-        address _manager
+        address _manager,
+        address _trustedForwarder
     )
         AccessControlRegistryAdminnedWithManager(
             _accessControlRegistry,
             _adminRoleDescription,
             _manager
         )
+        Allocator(_trustedForwarder)
     {
         slotSetterRole = _deriveRole(
             adminRole,
@@ -51,7 +55,7 @@ contract AllocatorWithManager is
         uint64 expirationTimestamp
     ) external override {
         require(
-            hasSlotSetterRoleOrIsManager(msg.sender),
+            hasSlotSetterRoleOrIsManager(_msgSender()),
             "Sender cannot set slot"
         );
         _setSlot(airnode, slotIndex, subscriptionId, expirationTimestamp);

--- a/contracts/authorizers/RequesterAuthorizer.sol
+++ b/contracts/authorizers/RequesterAuthorizer.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import "../whitelist/Whitelist.sol";
 import "./interfaces/IRequesterAuthorizer.sol";
 
@@ -9,7 +10,15 @@ import "./interfaces/IRequesterAuthorizer.sol";
 /// or Airnodes
 /// @dev An authorization for an Airnode with endpoint ID `bytes32(0)`
 /// represents a blanket authorization across all endpoints of the Airnode
-abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
+abstract contract RequesterAuthorizer is
+    ERC2771Context,
+    Whitelist,
+    IRequesterAuthorizer
+{
+    /// @param _trustedForwarder Trusted forwarder that verifies and executes
+    /// signed meta-calls
+    constructor(address _trustedForwarder) ERC2771Context(_trustedForwarder) {}
+
     /// @notice Extends the expiration of the temporary whitelist of
     /// `requester` for the `airnode`–`endpointId` pair and emits an event
     /// @param airnode Airnode address
@@ -34,7 +43,7 @@ abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
             airnode,
             endpointId,
             requester,
-            msg.sender,
+            _msgSender(),
             expirationTimestamp
         );
     }
@@ -64,7 +73,7 @@ abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
             airnode,
             endpointId,
             requester,
-            msg.sender,
+            _msgSender(),
             expirationTimestamp
         );
     }
@@ -93,7 +102,7 @@ abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
             airnode,
             endpointId,
             requester,
-            msg.sender,
+            _msgSender(),
             status,
             indefiniteWhitelistCount
         );
@@ -130,7 +139,7 @@ abstract contract RequesterAuthorizer is Whitelist, IRequesterAuthorizer {
                 endpointId,
                 requester,
                 setter,
-                msg.sender,
+                _msgSender(),
                 indefiniteWhitelistCount
             );
         }

--- a/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
@@ -14,11 +14,15 @@ contract RequesterAuthorizerWithAirnode is
 {
     /// @param _accessControlRegistry AccessControlRegistry contract address
     /// @param _adminRoleDescription Admin role description
+    /// @param _trustedForwarder Trusted forwarder that verifies and executes
+    /// signed meta-calls
     constructor(
         address _accessControlRegistry,
-        string memory _adminRoleDescription
+        string memory _adminRoleDescription,
+        address _trustedForwarder
     )
         WhitelistRolesWithAirnode(_accessControlRegistry, _adminRoleDescription)
+        RequesterAuthorizer(_trustedForwarder)
     {}
 
     /// @notice Extends the expiration of the temporary whitelist of
@@ -36,7 +40,10 @@ contract RequesterAuthorizerWithAirnode is
         uint64 expirationTimestamp
     ) external override {
         require(
-            hasWhitelistExpirationExtenderRoleOrIsAirnode(airnode, msg.sender),
+            hasWhitelistExpirationExtenderRoleOrIsAirnode(
+                airnode,
+                _msgSender()
+            ),
             "Cannot extend expiration"
         );
         _extendWhitelistExpirationAndEmit(
@@ -63,7 +70,7 @@ contract RequesterAuthorizerWithAirnode is
         uint64 expirationTimestamp
     ) external override {
         require(
-            hasWhitelistExpirationSetterRoleOrIsAirnode(airnode, msg.sender),
+            hasWhitelistExpirationSetterRoleOrIsAirnode(airnode, _msgSender()),
             "Cannot set expiration"
         );
         _setWhitelistExpirationAndEmit(
@@ -88,7 +95,7 @@ contract RequesterAuthorizerWithAirnode is
         bool status
     ) external override {
         require(
-            hasIndefiniteWhitelisterRoleOrIsAirnode(airnode, msg.sender),
+            hasIndefiniteWhitelisterRoleOrIsAirnode(airnode, _msgSender()),
             "Cannot set indefinite status"
         );
         _setIndefiniteWhitelistStatusAndEmit(

--- a/contracts/authorizers/RequesterAuthorizerWithManager.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithManager.sol
@@ -15,16 +15,20 @@ contract RequesterAuthorizerWithManager is
     /// @param _accessControlRegistry AccessControlRegistry contract address
     /// @param _adminRoleDescription Admin role description
     /// @param _manager Manager address
+    /// @param _trustedForwarder Trusted forwarder that verifies and executes
+    /// signed meta-calls
     constructor(
         address _accessControlRegistry,
         string memory _adminRoleDescription,
-        address _manager
+        address _manager,
+        address _trustedForwarder
     )
         WhitelistRolesWithManager(
             _accessControlRegistry,
             _adminRoleDescription,
             _manager
         )
+        RequesterAuthorizer(_trustedForwarder)
     {}
 
     /// @notice Extends the expiration of the temporary whitelist of
@@ -42,7 +46,7 @@ contract RequesterAuthorizerWithManager is
         uint64 expirationTimestamp
     ) external override {
         require(
-            hasWhitelistExpirationExtenderRoleOrIsManager(msg.sender),
+            hasWhitelistExpirationExtenderRoleOrIsManager(_msgSender()),
             "Cannot extend expiration"
         );
         _extendWhitelistExpirationAndEmit(
@@ -69,7 +73,7 @@ contract RequesterAuthorizerWithManager is
         uint64 expirationTimestamp
     ) external override {
         require(
-            hasWhitelistExpirationSetterRoleOrIsManager(msg.sender),
+            hasWhitelistExpirationSetterRoleOrIsManager(_msgSender()),
             "Cannot set expiration"
         );
         _setWhitelistExpirationAndEmit(
@@ -94,7 +98,7 @@ contract RequesterAuthorizerWithManager is
         bool status
     ) external override {
         require(
-            hasIndefiniteWhitelisterRoleOrIsManager(msg.sender),
+            hasIndefiniteWhitelisterRoleOrIsManager(_msgSender()),
             "Cannot set indefinite status"
         );
         _setIndefiniteWhitelistStatusAndEmit(

--- a/contracts/utils/ExpiringMetaCallForwarder.sol
+++ b/contracts/utils/ExpiringMetaCallForwarder.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
+import "./SelfMulticall.sol";
+
+/// @notice Contract that forwards expiring meta-calls to ERC2771 contracts
+/// that trust it
+/// @dev The term "meta-call" is used as a subset of "meta-tx" where `value`
+/// is zero and `to` is a contract.
+/// Adapted from OpenZeppelin's MinimalForwarder.sol.
+contract ExpiringMetaCallForwarder is EIP712, SelfMulticall {
+    using ECDSA for bytes32;
+    using Address for address;
+
+    struct ExpiringMetaCall {
+        address from;
+        address to;
+        bytes data;
+        uint256 expirationTimestamp;
+    }
+
+    /// @notice If the meta-call with hash is already executed
+    mapping(bytes32 => bool) public metaCallWithHashIsExecuted;
+
+    bytes32 private constant _TYPEHASH =
+        keccak256(
+            "ExpiringMetaCall(address from,address to,bytes data,uint256 expirationTimestamp)"
+        );
+
+    constructor() EIP712("ExpiringMetaCallForwarder", "1.0.0") {}
+
+    /// @notice Verifies the signature and executes the meta-call
+    /// @dev This implementation is intended for use-cases where both `from`
+    /// and the meta-call executor benefit from the meta-call being executed
+    /// directly (e.g., `from` wants to whitelist the executor but does not
+    /// have funds, so they give the executor a meta-call to execute on their
+    /// behalf). This means a lot of the security considerations that apply in
+    /// general relayer network implementations are irrelevant here.
+    /// @param metaCall Meta-call
+    /// @param signature Meta-call hash signed by `from`
+    /// @return returndata Returndata
+    function execute(
+        ExpiringMetaCall calldata metaCall,
+        bytes calldata signature
+    ) external returns (bytes memory returndata) {
+        bytes32 metaCallHash = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    _TYPEHASH,
+                    metaCall.from,
+                    metaCall.to,
+                    keccak256(metaCall.data),
+                    metaCall.expirationTimestamp
+                )
+            )
+        );
+        require(
+            !metaCallWithHashIsExecuted[metaCallHash],
+            "Meta-call already executed"
+        );
+        require(
+            metaCall.expirationTimestamp > block.timestamp,
+            "Meta-call expired"
+        );
+        require(
+            metaCallHash.recover(signature) == metaCall.from,
+            "Invalid signature"
+        );
+        metaCallWithHashIsExecuted[metaCallHash] = true;
+        returndata = metaCall.to.functionCall(
+            abi.encodePacked(metaCall.data, metaCall.from)
+        );
+    }
+}

--- a/contracts/utils/mock/MockExpiringMetaCallForwarderTarget.sol
+++ b/contracts/utils/mock/MockExpiringMetaCallForwarderTarget.sol
@@ -2,19 +2,36 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract MockExpiringMetaCallForwarderTarget is ERC2771Context {
-    address public immutable deployer;
+contract MockExpiringMetaCallForwarderTarget is ERC2771Context, Ownable {
     uint256 public counter = 0;
 
     /// @param _trustedForwarder Trusted forwarder that verifies and executes
     /// signed meta-calls
-    constructor(address _trustedForwarder) ERC2771Context(_trustedForwarder) {
-        deployer = msg.sender;
+    constructor(address _trustedForwarder) ERC2771Context(_trustedForwarder) {}
+
+    function incrementCounter() external onlyOwner {
+        counter++;
     }
 
-    function incrementCounter() external {
-        require(_msgSender() == deployer, "Sender not deployer");
-        counter++;
+    function _msgSender()
+        internal
+        view
+        virtual
+        override(Context, ERC2771Context)
+        returns (address sender)
+    {
+        return ERC2771Context._msgSender();
+    }
+
+    function _msgData()
+        internal
+        view
+        virtual
+        override(Context, ERC2771Context)
+        returns (bytes calldata)
+    {
+        return ERC2771Context._msgData();
     }
 }

--- a/contracts/utils/mock/MockExpiringMetaCallForwarderTarget.sol
+++ b/contracts/utils/mock/MockExpiringMetaCallForwarderTarget.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/metatx/ERC2771Context.sol";
+
+contract MockExpiringMetaCallForwarderTarget is ERC2771Context {
+    address public immutable deployer;
+    uint256 public counter = 0;
+
+    /// @param _trustedForwarder Trusted forwarder that verifies and executes
+    /// signed meta-calls
+    constructor(address _trustedForwarder) ERC2771Context(_trustedForwarder) {
+        deployer = msg.sender;
+    }
+
+    function incrementCounter() external {
+        require(_msgSender() == deployer, "Sender not deployer");
+        counter++;
+    }
+}

--- a/test/allocators/AllocatorWithAirnode.sol.js
+++ b/test/allocators/AllocatorWithAirnode.sol.js
@@ -4,7 +4,7 @@ const testUtils = require('../test-utils');
 
 describe('AllocatorWithAirnode', function () {
   let roles;
-  let accessControlRegistry, allocatorWithAirnode;
+  let expiringMetaCallForwarder, accessControlRegistry, allocatorWithAirnode;
   let allocatorWithAirnodeAdminRoleDescription = 'AllocatorWithAirnode admin role';
   let slotSetterRoleDescription = 'Slot setter';
   let airnodeSlotSetterRole;
@@ -21,12 +21,18 @@ describe('AllocatorWithAirnode', function () {
       anotherSlotSetter: accounts[3],
       randomPerson: accounts[9],
     };
+    const expiringMetaCallForwarderFactory = await hre.ethers.getContractFactory(
+      'ExpiringMetaCallForwarder',
+      roles.deployer
+    );
+    expiringMetaCallForwarder = await expiringMetaCallForwarderFactory.deploy();
     const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
     accessControlRegistry = await accessControlRegistryFactory.deploy();
     const allocatorWithAirnodeFactory = await hre.ethers.getContractFactory('AllocatorWithAirnode', roles.deployer);
     allocatorWithAirnode = await allocatorWithAirnodeFactory.deploy(
       accessControlRegistry.address,
-      allocatorWithAirnodeAdminRoleDescription
+      allocatorWithAirnodeAdminRoleDescription,
+      expiringMetaCallForwarder.address
     );
     const airnodeRootRole = await accessControlRegistry.deriveRootRole(roles.airnode.address);
     const airnodeAdminRole = await allocatorWithAirnode.deriveAdminRole(roles.airnode.address);

--- a/test/allocators/AllocatorWithAirnode.sol.js
+++ b/test/allocators/AllocatorWithAirnode.sol.js
@@ -55,6 +55,7 @@ describe('AllocatorWithAirnode', function () {
   describe('constructor', function () {
     it('constructs', async function () {
       expect(await allocatorWithAirnode.SLOT_SETTER_ROLE_DESCRIPTION()).to.equal(slotSetterRoleDescription);
+      expect(await allocatorWithAirnode.isTrustedForwarder(expiringMetaCallForwarder.address)).to.equal(true);
     });
   });
 

--- a/test/allocators/AllocatorWithManager.sol.js
+++ b/test/allocators/AllocatorWithManager.sol.js
@@ -69,6 +69,7 @@ describe('AllocatorWithManager', function () {
         hre.ethers.utils.solidityPack(['bytes32', 'bytes32'], [adminRole, slotSetterRoleDescriptionHash])
       );
       expect(await allocatorWithManager.slotSetterRole()).to.equal(derivedSlotSetterRole);
+      expect(await allocatorWithManager.isTrustedForwarder(expiringMetaCallForwarder.address)).to.equal(true);
     });
   });
 

--- a/test/allocators/AllocatorWithManager.sol.js
+++ b/test/allocators/AllocatorWithManager.sol.js
@@ -4,7 +4,7 @@ const testUtils = require('../test-utils');
 
 describe('AllocatorWithManager', function () {
   let roles;
-  let accessControlRegistry, allocatorWithManager;
+  let expiringMetaCallForwarder, accessControlRegistry, allocatorWithManager;
   let allocatorWithManagerAdminRoleDescription = 'AllocatorWithManager admin role';
   let slotSetterRoleDescription = 'Slot setter';
   let slotSetterRole;
@@ -22,13 +22,19 @@ describe('AllocatorWithManager', function () {
       anotherSlotSetter: accounts[4],
       randomPerson: accounts[9],
     };
+    const expiringMetaCallForwarderFactory = await hre.ethers.getContractFactory(
+      'ExpiringMetaCallForwarder',
+      roles.deployer
+    );
+    expiringMetaCallForwarder = await expiringMetaCallForwarderFactory.deploy();
     const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
     accessControlRegistry = await accessControlRegistryFactory.deploy();
     const allocatorWithManagerFactory = await hre.ethers.getContractFactory('AllocatorWithManager', roles.deployer);
     allocatorWithManager = await allocatorWithManagerFactory.deploy(
       accessControlRegistry.address,
       allocatorWithManagerAdminRoleDescription,
-      roles.manager.address
+      roles.manager.address,
+      expiringMetaCallForwarder.address
     );
     const managerRootRole = await accessControlRegistry.deriveRootRole(roles.manager.address);
     const managerAdminRole = await allocatorWithManager.adminRole();

--- a/test/authorizers/RequesterAuthorizerWithAirnode.sol.js
+++ b/test/authorizers/RequesterAuthorizerWithAirnode.sol.js
@@ -161,6 +161,9 @@ describe('RequesterAuthorizerWithAirnode', function () {
           expect(await requesterAuthorizerWithAirnode.adminRoleDescription()).to.equal(
             requesterAuthorizerWithAirnodeAdminRoleDescription
           );
+          expect(await requesterAuthorizerWithAirnode.isTrustedForwarder(expiringMetaCallForwarder.address)).to.equal(
+            true
+          );
         });
       });
       context('Admin role description string is empty', function () {

--- a/test/authorizers/RequesterAuthorizerWithManager.sol.js
+++ b/test/authorizers/RequesterAuthorizerWithManager.sol.js
@@ -148,6 +148,9 @@ describe('RequesterAuthorizerWithManager', function () {
               requesterAuthorizerWithManagerAdminRoleDescription
             );
             expect(await requesterAuthorizerWithManager.manager()).to.equal(roles.manager.address);
+            expect(await requesterAuthorizerWithManager.isTrustedForwarder(expiringMetaCallForwarder.address)).to.equal(
+              true
+            );
           });
         });
         context('Manager address is zero', function () {

--- a/test/monetization/RequesterAuthorizerWhitelisterWithTokenDeposit.sol.js
+++ b/test/monetization/RequesterAuthorizerWhitelisterWithTokenDeposit.sol.js
@@ -4,7 +4,8 @@ const testUtils = require('../test-utils');
 
 describe('RequesterAuthorizerWhitelisterWithTokenDeposit', function () {
   let roles;
-  let accessControlRegistry,
+  let expiringMetaCallForwarder,
+    accessControlRegistry,
     airnodeEndpointPriceRegistry,
     requesterAuthorizerRegistry,
     requesterAuthorizerWithManager,
@@ -32,6 +33,11 @@ describe('RequesterAuthorizerWhitelisterWithTokenDeposit', function () {
       anotherDepositor: accounts[7],
       randomPerson: accounts[9],
     };
+    const expiringMetaCallForwarderFactory = await hre.ethers.getContractFactory(
+      'ExpiringMetaCallForwarder',
+      roles.deployer
+    );
+    expiringMetaCallForwarder = await expiringMetaCallForwarderFactory.deploy();
     const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
     accessControlRegistry = await accessControlRegistryFactory.deploy();
     const airnodeEndpointPriceRegistryFactory = await hre.ethers.getContractFactory(
@@ -59,7 +65,8 @@ describe('RequesterAuthorizerWhitelisterWithTokenDeposit', function () {
     requesterAuthorizerWithManager = await requesterAuthorizerWithManagerFactory.deploy(
       accessControlRegistry.address,
       'RequesterAuthorizerWithManager admin',
-      roles.manager.address
+      roles.manager.address,
+      expiringMetaCallForwarder.address
     );
     await requesterAuthorizerRegistry
       .connect(roles.manager)

--- a/test/monetization/RequesterAuthorizerWhitelisterWithTokenPayment.sol.js
+++ b/test/monetization/RequesterAuthorizerWhitelisterWithTokenPayment.sol.js
@@ -4,7 +4,8 @@ const testUtils = require('../test-utils');
 
 describe('RequesterAuthorizerWhitelisterWithTokenPayment', function () {
   let roles;
-  let accessControlRegistry,
+  let expiringMetaCallForwarder,
+    accessControlRegistry,
     airnodeEndpointPriceRegistry,
     requesterAuthorizerRegistry,
     requesterAuthorizerWithManager,
@@ -31,6 +32,11 @@ describe('RequesterAuthorizerWhitelisterWithTokenPayment', function () {
       payer: accounts[6],
       randomPerson: accounts[9],
     };
+    const expiringMetaCallForwarderFactory = await hre.ethers.getContractFactory(
+      'ExpiringMetaCallForwarder',
+      roles.deployer
+    );
+    expiringMetaCallForwarder = await expiringMetaCallForwarderFactory.deploy();
     const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
     accessControlRegistry = await accessControlRegistryFactory.deploy();
     const airnodeEndpointPriceRegistryFactory = await hre.ethers.getContractFactory(
@@ -58,7 +64,8 @@ describe('RequesterAuthorizerWhitelisterWithTokenPayment', function () {
     requesterAuthorizerWithManager = await requesterAuthorizerWithManagerFactory.deploy(
       accessControlRegistry.address,
       'RequesterAuthorizerWithManager admin',
-      roles.manager.address
+      roles.manager.address,
+      expiringMetaCallForwarder.address
     );
     await requesterAuthorizerRegistry
       .connect(roles.manager)

--- a/test/utils/ExpiringMetaCallForwarder.sol.js
+++ b/test/utils/ExpiringMetaCallForwarder.sol.js
@@ -98,9 +98,7 @@ describe('ExpiringMetaCallForwarder', function () {
             const signature = await roles.deployer._signTypedData(domain, types, value);
             const counterBefore = await expiringMetaCallForwarderTarget.counter();
             await expect(
-              expiringMetaCallForwarder
-                .connect(roles.randomPerson)
-                .execute({ from, to, data, expirationTimestamp }, signature)
+              expiringMetaCallForwarder.connect(roles.randomPerson).execute(value, signature)
             ).to.not.be.reverted;
             expect(await expiringMetaCallForwarderTarget.counter()).to.be.equal(counterBefore.add(1));
           });
@@ -139,9 +137,7 @@ describe('ExpiringMetaCallForwarder', function () {
             };
             const signature = await roles.randomPerson._signTypedData(domain, types, value);
             await expect(
-              expiringMetaCallForwarder
-                .connect(roles.randomPerson)
-                .execute({ from, to, data, expirationTimestamp }, signature)
+              expiringMetaCallForwarder.connect(roles.randomPerson).execute(value, signature)
             ).to.be.revertedWith('Invalid signature');
           });
         });
@@ -180,9 +176,7 @@ describe('ExpiringMetaCallForwarder', function () {
           };
           const signature = await roles.deployer._signTypedData(domain, types, value);
           await expect(
-            expiringMetaCallForwarder
-              .connect(roles.randomPerson)
-              .execute({ from, to, data, expirationTimestamp }, signature)
+            expiringMetaCallForwarder.connect(roles.randomPerson).execute(value, signature)
           ).to.be.revertedWith('Meta-call expired');
         });
       });
@@ -220,13 +214,9 @@ describe('ExpiringMetaCallForwarder', function () {
           expirationTimestamp,
         };
         const signature = await roles.deployer._signTypedData(domain, types, value);
-        await expiringMetaCallForwarder
-          .connect(roles.randomPerson)
-          .execute({ from, to, data, expirationTimestamp }, signature);
+        await expiringMetaCallForwarder.connect(roles.randomPerson).execute(value, signature);
         await expect(
-          expiringMetaCallForwarder
-            .connect(roles.randomPerson)
-            .execute({ from, to, data, expirationTimestamp }, signature)
+          expiringMetaCallForwarder.connect(roles.randomPerson).execute(value, signature)
         ).to.be.revertedWith('Meta-call already executed');
       });
     });

--- a/test/utils/ExpiringMetaCallForwarder.sol.js
+++ b/test/utils/ExpiringMetaCallForwarder.sol.js
@@ -1,0 +1,285 @@
+const hre = require('hardhat');
+const { expect } = require('chai');
+const testUtils = require('../test-utils');
+
+describe('ExpiringMetaCallForwarder', function () {
+  let roles;
+  let expiringMetaCallForwarder, expiringMetaCallForwarderTarget;
+
+  beforeEach(async () => {
+    const accounts = await hre.ethers.getSigners();
+    roles = {
+      deployer: accounts[0],
+      randomPerson: accounts[9],
+    };
+    const expiringMetaCallForwarderFactory = await hre.ethers.getContractFactory(
+      'ExpiringMetaCallForwarder',
+      roles.deployer
+    );
+    expiringMetaCallForwarder = await expiringMetaCallForwarderFactory.deploy();
+    const expiringMetaCallForwarderTargetFactory = await hre.ethers.getContractFactory(
+      'MockExpiringMetaCallForwarderTarget',
+      roles.deployer
+    );
+    expiringMetaCallForwarderTarget = await expiringMetaCallForwarderTargetFactory.deploy(
+      expiringMetaCallForwarder.address
+    );
+  });
+
+  describe('execute', function () {
+    context('Meta-call with hash is not executed', function () {
+      context('Meta-call has not expired', function () {
+        context('Signature is valid', function () {
+          it('executes', async function () {
+            const from = roles.deployer.address;
+            const to = expiringMetaCallForwarderTarget.address;
+            const data = expiringMetaCallForwarderTarget.interface.encodeFunctionData('incrementCounter', []);
+            const expirationTimestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 3600;
+
+            const domainName = 'ExpiringMetaCallForwarder';
+            const domainVersion = '1.0.0';
+            const domainChainId = (await hre.ethers.provider.getNetwork()).chainId;
+            const domainAddress = expiringMetaCallForwarder.address;
+            /*
+            // Domain separator derivation
+            const domainTypeHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.toUtf8Bytes(
+                'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
+              )
+            );
+            const nameHash = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes(domainName));
+            const versionHash = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes(domainVersion));
+            const domainSeparator = hre.ethers.utils.keccak256(
+              hre.ethers.utils.defaultAbiCoder.encode(
+                ['bytes32', 'bytes32', 'bytes32', 'uint256', 'address'],
+                [domainTypeHash, nameHash, versionHash, domainChainId, domainAddress]
+              )
+            );
+
+            // Struct hash derivation
+            const structTypeHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.toUtf8Bytes(
+                'ExpiringMetaCall(address from,address to,bytes data,uint256 expirationTimestamp)'
+              )
+            );
+            const structHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.defaultAbiCoder.encode(
+                ['bytes32', 'address', 'address', 'bytes32', 'uint256'],
+                [structTypeHash, from, to, hre.ethers.utils.keccak256(data), expirationTimestamp]
+              )
+            );
+
+            // Typed data hash derivation
+            const typedDataHash = hre.ethers.utils.keccak256(
+              hre.ethers.utils.solidityPack(['string', 'bytes32', 'bytes32'], ['\x19\x01', domainSeparator, structHash])
+            );
+            */
+
+            const domain = {
+              name: domainName,
+              version: domainVersion,
+              chainId: domainChainId,
+              verifyingContract: domainAddress,
+            };
+            const types = {
+              ExpiringMetaCall: [
+                { name: 'from', type: 'address' },
+                { name: 'to', type: 'address' },
+                { name: 'data', type: 'bytes' },
+                { name: 'expirationTimestamp', type: 'uint256' },
+              ],
+            };
+            const value = {
+              from,
+              to,
+              data,
+              expirationTimestamp,
+            };
+            const signature = await roles.deployer._signTypedData(domain, types, value);
+            const counterBefore = await expiringMetaCallForwarderTarget.counter();
+            await expect(
+              expiringMetaCallForwarder
+                .connect(roles.randomPerson)
+                .execute({ from, to, data, expirationTimestamp }, signature)
+            ).to.not.be.reverted;
+            expect(await expiringMetaCallForwarderTarget.counter()).to.be.equal(counterBefore.add(1));
+          });
+        });
+        context('Signature is not valid', function () {
+          it('reverts', async function () {
+            const from = roles.deployer.address;
+            const to = expiringMetaCallForwarderTarget.address;
+            const data = expiringMetaCallForwarderTarget.interface.encodeFunctionData('incrementCounter', []);
+            const expirationTimestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 3600;
+
+            const domainName = 'ExpiringMetaCallForwarder';
+            const domainVersion = '1.0.0';
+            const domainChainId = (await hre.ethers.provider.getNetwork()).chainId;
+            const domainAddress = expiringMetaCallForwarder.address;
+
+            const domain = {
+              name: domainName,
+              version: domainVersion,
+              chainId: domainChainId,
+              verifyingContract: domainAddress,
+            };
+            const types = {
+              ExpiringMetaCall: [
+                { name: 'from', type: 'address' },
+                { name: 'to', type: 'address' },
+                { name: 'data', type: 'bytes' },
+                { name: 'expirationTimestamp', type: 'uint256' },
+              ],
+            };
+            const value = {
+              from,
+              to,
+              data,
+              expirationTimestamp,
+            };
+            const signature = await roles.randomPerson._signTypedData(domain, types, value);
+            await expect(
+              expiringMetaCallForwarder
+                .connect(roles.randomPerson)
+                .execute({ from, to, data, expirationTimestamp }, signature)
+            ).to.be.revertedWith('Invalid signature');
+          });
+        });
+      });
+      context('Meta-call has expired', function () {
+        it('reverts', async function () {
+          const from = roles.deployer.address;
+          const to = expiringMetaCallForwarderTarget.address;
+          const data = expiringMetaCallForwarderTarget.interface.encodeFunctionData('incrementCounter', []);
+          const expirationTimestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) - 3600;
+
+          const domainName = 'ExpiringMetaCallForwarder';
+          const domainVersion = '1.0.0';
+          const domainChainId = (await hre.ethers.provider.getNetwork()).chainId;
+          const domainAddress = expiringMetaCallForwarder.address;
+
+          const domain = {
+            name: domainName,
+            version: domainVersion,
+            chainId: domainChainId,
+            verifyingContract: domainAddress,
+          };
+          const types = {
+            ExpiringMetaCall: [
+              { name: 'from', type: 'address' },
+              { name: 'to', type: 'address' },
+              { name: 'data', type: 'bytes' },
+              { name: 'expirationTimestamp', type: 'uint256' },
+            ],
+          };
+          const value = {
+            from,
+            to,
+            data,
+            expirationTimestamp,
+          };
+          const signature = await roles.deployer._signTypedData(domain, types, value);
+          await expect(
+            expiringMetaCallForwarder
+              .connect(roles.randomPerson)
+              .execute({ from, to, data, expirationTimestamp }, signature)
+          ).to.be.revertedWith('Meta-call expired');
+        });
+      });
+    });
+    context('Meta-call with hash is already executed', function () {
+      it('reverts', async function () {
+        const from = roles.deployer.address;
+        const to = expiringMetaCallForwarderTarget.address;
+        const data = expiringMetaCallForwarderTarget.interface.encodeFunctionData('incrementCounter', []);
+        const expirationTimestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 3600;
+
+        const domainName = 'ExpiringMetaCallForwarder';
+        const domainVersion = '1.0.0';
+        const domainChainId = (await hre.ethers.provider.getNetwork()).chainId;
+        const domainAddress = expiringMetaCallForwarder.address;
+
+        const domain = {
+          name: domainName,
+          version: domainVersion,
+          chainId: domainChainId,
+          verifyingContract: domainAddress,
+        };
+        const types = {
+          ExpiringMetaCall: [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'data', type: 'bytes' },
+            { name: 'expirationTimestamp', type: 'uint256' },
+          ],
+        };
+        const value = {
+          from,
+          to,
+          data,
+          expirationTimestamp,
+        };
+        const signature = await roles.deployer._signTypedData(domain, types, value);
+        await expiringMetaCallForwarder
+          .connect(roles.randomPerson)
+          .execute({ from, to, data, expirationTimestamp }, signature);
+        await expect(
+          expiringMetaCallForwarder
+            .connect(roles.randomPerson)
+            .execute({ from, to, data, expirationTimestamp }, signature)
+        ).to.be.revertedWith('Meta-call already executed');
+      });
+    });
+  });
+
+  describe('multicall', function () {
+    it('executes multiple calls', async function () {
+      const from = roles.deployer.address;
+      const to = expiringMetaCallForwarderTarget.address;
+      const data = expiringMetaCallForwarderTarget.interface.encodeFunctionData('incrementCounter', []);
+      const expirationTimestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 3600;
+
+      const domainName = 'ExpiringMetaCallForwarder';
+      const domainVersion = '1.0.0';
+      const domainChainId = (await hre.ethers.provider.getNetwork()).chainId;
+      const domainAddress = expiringMetaCallForwarder.address;
+
+      const domain = {
+        name: domainName,
+        version: domainVersion,
+        chainId: domainChainId,
+        verifyingContract: domainAddress,
+      };
+      const types = {
+        ExpiringMetaCall: [
+          { name: 'from', type: 'address' },
+          { name: 'to', type: 'address' },
+          { name: 'data', type: 'bytes' },
+          { name: 'expirationTimestamp', type: 'uint256' },
+        ],
+      };
+      const value1 = {
+        from,
+        to,
+        data,
+        expirationTimestamp,
+      };
+      const value2 = {
+        from,
+        to,
+        data,
+        expirationTimestamp: expirationTimestamp + 1,
+      };
+      const signature1 = await roles.deployer._signTypedData(domain, types, value1);
+      const signature2 = await roles.deployer._signTypedData(domain, types, value2);
+      const multicallData = [
+        expiringMetaCallForwarder.interface.encodeFunctionData('execute', [value1, signature1]),
+        expiringMetaCallForwarder.interface.encodeFunctionData('execute', [value2, signature2]),
+      ];
+
+      const counterBefore = await expiringMetaCallForwarderTarget.counter();
+      await expect(expiringMetaCallForwarder.connect(roles.randomPerson).multicall(multicallData)).to.not.be.reverted;
+      expect(await expiringMetaCallForwarderTarget.counter()).to.be.equal(counterBefore.add(2));
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode-protocol-v1/issues/38

The main use-case I was thinking about is a user sends a whitelisting request to an Airnode operator on ChainAPI on a random chain. The Airnode operator doesn't have the respective currency, and doesn't want to pay for other people's whitelisting. Then, they create a meta-tx, which ChainAPI sends to the requester to execute. Ideally this should be a whitelisted extension because the Airnode operator cannot undo the whitelisting for the same reasons that they can't execute the initial whitelisting.

Meta-txes typically use nonces to prevent replays. However, considering that there may be multiple parties that request such whitelistings, we can't use nonces. Note that this is because our use-case is fundamentally different from "gasless transactions". With gasless transactions, it's the signer that wants the transaction to be executed. In our case, it is some other party that wants the transactions to be executed, the only reason they can't is because they need the permission of the signer. This enables us to not bother with the complexity of a decentralized relayer network.