### PR TITLE
Domain signed data

### DIFF
--- a/contracts/utils/ExpiringMetaCallForwarder.sol
+++ b/contracts/utils/ExpiringMetaCallForwarder.sol
@@ -67,7 +67,7 @@ contract ExpiringMetaCallForwarder is EIP712, SelfMulticall {
         );
         require(
             metaCallHash.recover(signature) == metaCall.from,
-            "Invalid signature"
+            "Signature mismatch"
         );
         metaCallWithHashIsExecuted[metaCallHash] = true;
         returndata = metaCall.to.functionCall(

--- a/test/utils/ExpiringMetaCallForwarder.sol.js
+++ b/test/utils/ExpiringMetaCallForwarder.sol.js
@@ -138,7 +138,7 @@ describe('ExpiringMetaCallForwarder', function () {
             const signature = await roles.randomPerson._signTypedData(domain, types, value);
             await expect(
               expiringMetaCallForwarder.connect(roles.randomPerson).execute(value, signature)
-            ).to.be.revertedWith('Invalid signature');
+            ).to.be.revertedWith('Signature mismatch');
           });
         });
       });


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode-protocol-v1/issues/54

I didn't feel like implementing a separate function for this so just allowed both types of signatures, which means using domain-specific signatures will be significantly more expensive (because the contract will need to check if the signature is a generic one first). This may not be a good idea.