### PR TITLE
Domain signed data v2

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -717,7 +717,7 @@ contract DapiServer is
     }
 
     /// @notice Updates a Beacon set using data signed for this contract by the
-    ///  respective Airnodes without requiring a request or subscription. The
+    /// respective Airnodes without requiring a request or subscription. The
     /// Beacons for which the signature is omitted will be read from the
     /// storage.
     /// @param airnodes Airnode addresses

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -526,7 +526,11 @@ contract DapiServer is
         );
         bytes32 beaconId = deriveBeaconId(airnode, templateId);
         uint256 decodedData = processBeaconUpdate(beaconId, timestamp, data);
-        emit UpdatedBeaconWithSignedData(beaconId, decodedData, timestamp);
+        emit UpdatedBeaconWithDomainSignedData(
+            beaconId,
+            decodedData,
+            timestamp
+        );
     }
 
     ///                     ~~~PSP Beacon set updates~~~
@@ -797,7 +801,7 @@ contract DapiServer is
             value: updatedValue,
             timestamp: updatedTimestamp
         });
-        emit UpdatedBeaconSetWithSignedData(
+        emit UpdatedBeaconSetWithDomainSignedData(
             beaconSetId,
             updatedValue,
             updatedTimestamp

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -61,6 +61,11 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
         uint256 value,
         uint256 timestamp
     );
+    event UpdatedBeaconWithDomainSignedData(
+        bytes32 indexed beaconId,
+        uint256 value,
+        uint256 timestamp
+    );
 
     event UpdatedBeaconSetWithBeacons(
         bytes32 indexed beaconSetId,
@@ -69,6 +74,12 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
     );
 
     event UpdatedBeaconSetWithSignedData(
+        bytes32 indexed dapiId,
+        uint224 value,
+        uint32 timestamp
+    );
+
+    event UpdatedBeaconSetWithDomainSignedData(
         bytes32 indexed dapiId,
         uint224 value,
         uint32 timestamp

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -151,6 +151,14 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
         bytes calldata signature
     ) external;
 
+    function updateBeaconWithDomainSignedData(
+        address airnode,
+        bytes32 templateId,
+        uint256 timestamp,
+        bytes calldata data,
+        bytes calldata signature
+    ) external;
+
     function updateBeaconSetWithBeacons(bytes32[] memory beaconIds)
         external
         returns (bytes32 beaconSetId);
@@ -172,6 +180,14 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
     ) external;
 
     function updateBeaconSetWithSignedData(
+        address[] memory airnodes,
+        bytes32[] memory templateIds,
+        uint256[] memory timestamps,
+        bytes[] memory data,
+        bytes[] memory signatures
+    ) external returns (bytes32 beaconSetId);
+
+    function updateBeaconSetWithDomainSignedData(
         address[] memory airnodes,
         bytes32[] memory templateIds,
         uint256[] memory timestamps,

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -1874,7 +1874,7 @@ describe('DapiServer', function () {
                   .connect(roles.randomPerson)
                   .updateBeaconWithDomainSignedData(airnodeAddress, templateId, timestamp, data, signature)
               )
-                .to.emit(dapiServer, 'UpdatedBeaconWithSignedData')
+                .to.emit(dapiServer, 'UpdatedBeaconWithDomainSignedData')
                 .withArgs(beaconId, 123, timestamp);
               const beacon = await dapiServer.readDataFeedWithId(beaconId);
               expect(beacon.value).to.equal(123);
@@ -2758,7 +2758,7 @@ describe('DapiServer', function () {
                           ['0x', signature1, signature2]
                         )
                     )
-                      .to.emit(dapiServer, 'UpdatedBeaconSetWithSignedData')
+                      .to.emit(dapiServer, 'UpdatedBeaconSetWithDomainSignedData')
                       .withArgs(beaconSetId, 105, timestamp);
                     const beaconSet = await dapiServer.readDataFeedWithId(beaconSetId);
                     expect(beaconSet.value).to.equal(105);

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -302,6 +302,21 @@ describe('DapiServer', function () {
     return [data, signature];
   }
 
+  async function encodeAndDomainSignData(decodedData, templateId, timestamp) {
+    const data = encodeData(decodedData);
+    const signature = await airnodeWallet.signMessage(
+      hre.ethers.utils.arrayify(
+        hre.ethers.utils.keccak256(
+          hre.ethers.utils.solidityPack(
+            ['uint256', 'address', 'bytes32', 'uint256', 'bytes'],
+            [(await hre.ethers.provider.getNetwork()).chainId, dapiServer.address, templateId, timestamp, data]
+          )
+        )
+      )
+    );
+    return [data, signature];
+  }
+
   async function deriveRegularRequestId() {
     return hre.ethers.utils.keccak256(
       hre.ethers.utils.solidityPack(
@@ -1845,6 +1860,96 @@ describe('DapiServer', function () {
     });
   });
 
+  describe('updateBeaconWithDomainSignedData', function () {
+    context('Timestamp is valid', function () {
+      context('Signature is valid', function () {
+        context('Data length is correct', function () {
+          context('Data is fresher than Beacon', function () {
+            it('updates Beacon', async function () {
+              const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+              await hre.ethers.provider.send('evm_setNextBlockTimestamp', [timestamp]);
+              const [data, signature] = await encodeAndDomainSignData(123, templateId, timestamp);
+              await expect(
+                dapiServer
+                  .connect(roles.randomPerson)
+                  .updateBeaconWithDomainSignedData(airnodeAddress, templateId, timestamp, data, signature)
+              )
+                .to.emit(dapiServer, 'UpdatedBeaconWithSignedData')
+                .withArgs(beaconId, 123, timestamp);
+              const beacon = await dapiServer.readDataFeedWithId(beaconId);
+              expect(beacon.value).to.equal(123);
+              expect(beacon.timestamp).to.equal(timestamp);
+            });
+          });
+          context('Data is not fresher than Beacon', function () {
+            it('reverts', async function () {
+              const initialTimestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+              const futureTimestamp = initialTimestamp + 1;
+              await setBeacon(templateId, 123, futureTimestamp);
+              await hre.ethers.provider.send('evm_setNextBlockTimestamp', [futureTimestamp + 1]);
+              const [data, signature] = await encodeAndDomainSignData(456, templateId, initialTimestamp);
+              await expect(
+                dapiServer
+                  .connect(roles.randomPerson)
+                  .updateBeaconWithDomainSignedData(airnodeAddress, templateId, initialTimestamp, data, signature)
+              ).to.be.revertedWith('Fulfillment older than Beacon');
+            });
+          });
+        });
+        context('Data length is not correct', function () {
+          it('reverts', async function () {
+            const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+            await hre.ethers.provider.send('evm_setNextBlockTimestamp', [timestamp]);
+            const data = encodeData(123);
+            const longData = data + '00';
+            const signature = await airnodeWallet.signMessage(
+              hre.ethers.utils.arrayify(
+                hre.ethers.utils.keccak256(
+                  hre.ethers.utils.solidityPack(
+                    ['uint256', 'address', 'bytes32', 'uint256', 'bytes'],
+                    [
+                      (await hre.ethers.provider.getNetwork()).chainId,
+                      dapiServer.address,
+                      templateId,
+                      timestamp,
+                      longData,
+                    ]
+                  )
+                )
+              )
+            );
+            await expect(
+              dapiServer
+                .connect(roles.randomPerson)
+                .updateBeaconWithDomainSignedData(airnodeAddress, templateId, timestamp, longData, signature)
+            ).to.be.revertedWith('Data length not correct');
+          });
+        });
+      });
+      context('Signature is not valid', function () {
+        it('reverts', async function () {
+          const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+          await hre.ethers.provider.send('evm_setNextBlockTimestamp', [timestamp]);
+          await expect(
+            dapiServer
+              .connect(roles.randomPerson)
+              .updateBeaconWithDomainSignedData(airnodeAddress, templateId, timestamp, '0x', '0x')
+          ).to.be.revertedWith('ECDSA: invalid signature length');
+        });
+      });
+    });
+    context('Timestamp is not valid', function () {
+      it('reverts', async function () {
+        const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) - 60 * 60;
+        await expect(
+          dapiServer
+            .connect(roles.randomPerson)
+            .updateBeaconWithDomainSignedData(airnodeAddress, templateId, timestamp, '0x', '0x')
+        ).to.be.revertedWith('Timestamp not valid');
+      });
+    });
+  });
+
   describe('updateBeaconSetWithBeacons', function () {
     context('Did not specify less than two Beacons', function () {
       context('Updated value is not outdated', function () {
@@ -2614,6 +2719,292 @@ describe('DapiServer', function () {
           dapiServer
             .connect(roles.randomPerson)
             .updateBeaconSetWithSignedData(
+              Array(3).fill(testUtils.generateRandomAddress()),
+              Array(3).fill(testUtils.generateRandomBytes32()),
+              Array(3).fill(0),
+              Array(3).fill(testUtils.generateRandomBytes()),
+              Array(4).fill(testUtils.generateRandomBytes())
+            )
+        ).to.be.revertedWith('Parameter length mismatch');
+      });
+    });
+  });
+
+  describe('updateBeaconSetWithDomainSignedData', function () {
+    context('Parameter lengths match', function () {
+      context('Did not specify less than two Beacons', function () {
+        context('All signed timestamps are valid', function () {
+          context('All signatures are valid', function () {
+            context('All signed data has correct length', function () {
+              context('All signed data can be typecast successfully', function () {
+                context('Updated value is not outdated', function () {
+                  it('updates Beacon set with signed data', async function () {
+                    let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+                    // Set the first beacon to a value
+                    timestamp++;
+                    await setBeacon(beaconSetTemplateIds[0], 100, timestamp);
+                    // Sign data for the next two beacons
+                    const [data1, signature1] = await encodeAndDomainSignData(105, beaconSetTemplateIds[1], timestamp);
+                    const [data2, signature2] = await encodeAndDomainSignData(110, beaconSetTemplateIds[2], timestamp);
+                    // Pass an empty signature for the first beacon, meaning that it will be read from the storage
+                    await expect(
+                      dapiServer
+                        .connect(roles.randomPerson)
+                        .updateBeaconSetWithDomainSignedData(
+                          Array(3).fill(airnodeAddress),
+                          beaconSetTemplateIds,
+                          [0, timestamp, timestamp],
+                          ['0x', data1, data2],
+                          ['0x', signature1, signature2]
+                        )
+                    )
+                      .to.emit(dapiServer, 'UpdatedBeaconSetWithSignedData')
+                      .withArgs(beaconSetId, 105, timestamp);
+                    const beaconSet = await dapiServer.readDataFeedWithId(beaconSetId);
+                    expect(beaconSet.value).to.equal(105);
+                    expect(beaconSet.timestamp).to.equal(timestamp);
+                  });
+                });
+                context('Updated value is outdated', function () {
+                  it('reverts', async function () {
+                    let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+                    timestamp++;
+                    await setBeaconSet(
+                      airnodeAddress,
+                      beaconSetTemplateIds,
+                      Array(3).fill(100),
+                      Array(3).fill(timestamp)
+                    );
+                    // Set the first beacon to a value
+                    timestamp++;
+                    await setBeacon(beaconSetTemplateIds[0], 100, timestamp);
+                    // Sign data for the next two beacons
+                    const [data1, signature1] = await encodeAndDomainSignData(
+                      110,
+                      beaconSetTemplateIds[1],
+                      timestamp - 5
+                    );
+                    const [data2, signature2] = await encodeAndDomainSignData(
+                      105,
+                      beaconSetTemplateIds[2],
+                      timestamp - 5
+                    );
+                    // Pass an empty signature for the first beacon, meaning that it will be read from the storage
+                    await expect(
+                      dapiServer
+                        .connect(roles.randomPerson)
+                        .updateBeaconSetWithDomainSignedData(
+                          Array(3).fill(airnodeAddress),
+                          beaconSetTemplateIds,
+                          [0, timestamp - 5, timestamp - 5],
+                          ['0x', data1, data2],
+                          ['0x', signature1, signature2]
+                        )
+                    ).to.be.revertedWith('Updated value outdated');
+                  });
+                });
+              });
+              context('All signed data cannot be typecast successfully', function () {
+                it('reverts', async function () {
+                  let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+                  // Set the first beacon to a value
+                  timestamp++;
+                  await setBeacon(beaconSetTemplateIds[0], 100, timestamp);
+                  // Sign data for the next beacons
+                  const [data1, signature1] = await encodeAndDomainSignData(110, beaconSetTemplateIds[1], timestamp);
+                  // The third data contains an un-typecastable value
+                  const data2 = encodeData(hre.ethers.BigNumber.from(2).pow(224).add(1));
+                  const signature2 = await airnodeWallet.signMessage(
+                    hre.ethers.utils.arrayify(
+                      hre.ethers.utils.keccak256(
+                        hre.ethers.utils.solidityPack(
+                          ['uint256', 'address', 'bytes32', 'uint256', 'bytes'],
+                          [
+                            (await hre.ethers.provider.getNetwork()).chainId,
+                            dapiServer.address,
+                            beaconSetTemplateIds[2],
+                            timestamp,
+                            data2,
+                          ]
+                        )
+                      )
+                    )
+                  );
+                  // Pass an empty signature for the first beacon, meaning that it will be read from the storage
+                  await expect(
+                    dapiServer
+                      .connect(roles.randomPerson)
+                      .updateBeaconSetWithDomainSignedData(
+                        Array(3).fill(airnodeAddress),
+                        beaconSetTemplateIds,
+                        [0, timestamp, timestamp],
+                        ['0x', data1, data2],
+                        ['0x', signature1, signature2]
+                      )
+                  ).to.be.revertedWith('Value typecasting error');
+                });
+              });
+            });
+            context('Not all signed data has correct length', function () {
+              it('reverts', async function () {
+                let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+                // Set the first beacon to a value
+                timestamp++;
+                await setBeacon(beaconSetTemplateIds[0], 100, timestamp);
+                // Sign data for the next beacons
+                const [data1, signature1] = await encodeAndDomainSignData(110, beaconSetTemplateIds[1], timestamp);
+                // The third data does not have the correct length
+                const data2 = encodeData(105) + '00';
+                const signature2 = await airnodeWallet.signMessage(
+                  hre.ethers.utils.arrayify(
+                    hre.ethers.utils.keccak256(
+                      hre.ethers.utils.solidityPack(
+                        ['uint256', 'address', 'bytes32', 'uint256', 'bytes'],
+                        [
+                          (await hre.ethers.provider.getNetwork()).chainId,
+                          dapiServer.address,
+                          beaconSetTemplateIds[2],
+                          timestamp,
+                          data2,
+                        ]
+                      )
+                    )
+                  )
+                );
+                // Pass an empty signature for the first beacon, meaning that it will be read from the storage
+                await expect(
+                  dapiServer
+                    .connect(roles.randomPerson)
+                    .updateBeaconSetWithDomainSignedData(
+                      Array(3).fill(airnodeAddress),
+                      beaconSetTemplateIds,
+                      [0, timestamp, timestamp],
+                      ['0x', data1, data2],
+                      ['0x', signature1, signature2]
+                    )
+                ).to.be.revertedWith('Data length not correct');
+              });
+            });
+          });
+          context('Not all signatures are valid', function () {
+            it('reverts', async function () {
+              let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+              // Set the first beacon to a value
+              timestamp++;
+              await setBeacon(beaconSetTemplateIds[0], 100, timestamp);
+              // Sign data for the next two beacons
+              const [data1, signature1] = await encodeAndDomainSignData(110, beaconSetTemplateIds[1], timestamp);
+              const [data2] = await encodeAndDomainSignData(105, beaconSetTemplateIds[2], timestamp);
+              // Pass an empty signature for the first beacon, meaning that it will be read from the storage
+              // The signature for the third beacon is invalid
+              await expect(
+                dapiServer
+                  .connect(roles.randomPerson)
+                  .updateBeaconSetWithDomainSignedData(
+                    Array(3).fill(airnodeAddress),
+                    beaconSetTemplateIds,
+                    [0, timestamp, timestamp],
+                    ['0x', data1, data2],
+                    ['0x', signature1, '0x12345678']
+                  )
+              ).to.be.revertedWith('ECDSA: invalid signature length');
+            });
+          });
+        });
+        context('Not all signed timestamps are valid', function () {
+          it('reverts', async function () {
+            let timestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+            // Set the first beacon to a value
+            timestamp++;
+            await setBeacon(beaconSetTemplateIds[0], 100, timestamp);
+            // Sign data for the next two beacons
+            const [data1, signature1] = await encodeAndDomainSignData(110, beaconSetTemplateIds[1], timestamp);
+            const [data2, signature2] = await encodeAndDomainSignData(105, beaconSetTemplateIds[2], 0);
+            // Pass an empty signature for the first beacon, meaning that it will be read from the storage
+            // The timestamp for the third beacon is invalid
+            await expect(
+              dapiServer
+                .connect(roles.randomPerson)
+                .updateBeaconSetWithDomainSignedData(
+                  Array(3).fill(airnodeAddress),
+                  beaconSetTemplateIds,
+                  [0, timestamp, 0],
+                  ['0x', data1, data2],
+                  ['0x', signature1, signature2]
+                )
+            ).to.be.revertedWith('Timestamp not valid');
+          });
+        });
+      });
+      context('Specified less than two Beacons', function () {
+        it('reverts', async function () {
+          await expect(
+            dapiServer.connect(roles.randomPerson).updateBeaconSetWithDomainSignedData([], [], [], [], [])
+          ).to.be.revertedWith('Specified less than two Beacons');
+          await expect(
+            dapiServer
+              .connect(roles.randomPerson)
+              .updateBeaconSetWithDomainSignedData(
+                [testUtils.generateRandomAddress()],
+                [testUtils.generateRandomBytes32()],
+                [0],
+                [testUtils.generateRandomBytes()],
+                [testUtils.generateRandomBytes()]
+              )
+          ).to.be.revertedWith('Specified less than two Beacons');
+        });
+      });
+    });
+    context('Parameter lengths do not match', function () {
+      it('reverts', async function () {
+        await expect(
+          dapiServer
+            .connect(roles.randomPerson)
+            .updateBeaconSetWithDomainSignedData(
+              Array(4).fill(testUtils.generateRandomAddress()),
+              Array(3).fill(testUtils.generateRandomBytes32()),
+              Array(3).fill(0),
+              Array(3).fill(testUtils.generateRandomBytes()),
+              Array(3).fill(testUtils.generateRandomBytes())
+            )
+        ).to.be.revertedWith('Parameter length mismatch');
+        await expect(
+          dapiServer
+            .connect(roles.randomPerson)
+            .updateBeaconSetWithDomainSignedData(
+              Array(3).fill(testUtils.generateRandomAddress()),
+              Array(4).fill(testUtils.generateRandomBytes32()),
+              Array(3).fill(0),
+              Array(3).fill(testUtils.generateRandomBytes()),
+              Array(3).fill(testUtils.generateRandomBytes())
+            )
+        ).to.be.revertedWith('Parameter length mismatch');
+        await expect(
+          dapiServer
+            .connect(roles.randomPerson)
+            .updateBeaconSetWithDomainSignedData(
+              Array(3).fill(testUtils.generateRandomAddress()),
+              Array(3).fill(testUtils.generateRandomBytes32()),
+              Array(4).fill(0),
+              Array(3).fill(testUtils.generateRandomBytes()),
+              Array(3).fill(testUtils.generateRandomBytes())
+            )
+        ).to.be.revertedWith('Parameter length mismatch');
+        await expect(
+          dapiServer
+            .connect(roles.randomPerson)
+            .updateBeaconSetWithDomainSignedData(
+              Array(3).fill(testUtils.generateRandomAddress()),
+              Array(3).fill(testUtils.generateRandomBytes32()),
+              Array(3).fill(0),
+              Array(4).fill(testUtils.generateRandomBytes()),
+              Array(3).fill(testUtils.generateRandomBytes())
+            )
+        ).to.be.revertedWith('Parameter length mismatch');
+        await expect(
+          dapiServer
+            .connect(roles.randomPerson)
+            .updateBeaconSetWithDomainSignedData(
               Array(3).fill(testUtils.generateRandomAddress()),
               Array(3).fill(testUtils.generateRandomBytes32()),
               Array(3).fill(0),


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode-protocol-v1/issues/54

I didn't want to weigh down `updateBeaconSetWithSignedData()` so I just duplicated the implementation for domain-signed data. https://github.com/api3dao/airnode-protocol-v1/issues/34 also requires additions to DapiServer so this may cause the contract size limit to be exceeded. That can be addressed later.