### PR TITLE
Add deviationReference to PSP conditions

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -831,11 +831,13 @@ contract DapiServer is
 
     /// @notice Called privately to calculate the update magnitude in
     /// percentages where 100% is represented as `HUNDRED_PERCENT`
-    /// @dev The percentage changes will be more pronounced when the first
-    /// value is almost zero, which may trigger updates more frequently than
-    /// wanted. To avoid this, Beacons should be defined in a way that the
-    /// expected values are not small numbers floating around zero, i.e.,
-    /// offset and scale.
+    /// @dev The percentage changes will be more pronounced when the initial
+    /// value is closer to the deviation reference. Therefore, while deciding
+    /// on the subscription conditions, one should choose a deviation reference
+    /// that will produce the desired update behavior. In general, the
+    /// deviation reference should not be close to the operational range of the
+    /// data feed (e.g., if the value is expected to change between -10 and 10,
+    /// a deviation reference of -30 may be suitable.)
     /// @param initialValue Initial value
     /// @param updatedValue Updated value
     /// @param deviationReference Reference value that deviation will be

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -102,8 +102,8 @@ describe('DapiServer', function () {
     );
     // Deviation threshold is 10% and heartbeat interval is 1 day
     beaconUpdateSubscriptionConditionParameters = hre.ethers.utils.defaultAbiCoder.encode(
-      ['uint256', 'uint256'],
-      [(await dapiServer.HUNDRED_PERCENT()).div(10), 24 * 60 * 60]
+      ['uint256', 'int224', 'uint256'],
+      [(await dapiServer.HUNDRED_PERCENT()).div(10), 0, 24 * 60 * 60]
     );
     // Create Beacon update conditions using Airnode ABI
     beaconUpdateSubscriptionConditions = hre.ethers.utils.defaultAbiCoder.encode(
@@ -189,8 +189,8 @@ describe('DapiServer', function () {
     );
     // Deviation threshold is 5% and heartbeat interval is 2 days
     beaconSetUpdateSubscriptionConditionParameters = hre.ethers.utils.defaultAbiCoder.encode(
-      ['uint256', 'uint256'],
-      [(await dapiServer.HUNDRED_PERCENT()).div(20), 2 * 24 * 60 * 60]
+      ['uint256', 'int224', 'uint256'],
+      [(await dapiServer.HUNDRED_PERCENT()).div(20), 0, 2 * 24 * 60 * 60]
     );
     // Create Beacon set update conditions using Airnode ABI
     const beaconSetUpdateSubscriptionConditions = hre.ethers.utils.defaultAbiCoder.encode(
@@ -1082,7 +1082,10 @@ describe('DapiServer', function () {
               // Even if the deviation and heartbeat interval is zero, since the Beacon timestamp
               // is zero, the condition will return true
               const conditionData = encodeData(0);
-              const conditionParameters = hre.ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256'], [0, 0]);
+              const conditionParameters = hre.ethers.utils.defaultAbiCoder.encode(
+                ['uint256', 'int224', 'uint256'],
+                [0, 0, 0]
+              );
               expect(
                 await dapiServer.callStatic.conditionPspBeaconUpdate(
                   beaconUpdateSubscriptionId,
@@ -1190,17 +1193,15 @@ describe('DapiServer', function () {
             });
             context('Data does not make a larger update than the threshold', function () {
               context('Update is upwards', function () {
-                context('It has been at least heartbeat interval seconds since the last update', function () {
+                context('Initial value is deviation reference', function () {
                   it('returns true', async function () {
-                    // Set the Beacon to 100 first
+                    // Set the Beacon to 0 first
                     const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                    await setBeacon(templateId, 100, timestamp);
-                    // beaconUpdateSubscriptionConditionParameters is 10% and 1 day
-                    // 100 -> 109 doesn't satisfy the condition
-                    const conditionData = encodeData(109);
-                    // It has been 1 day since the Beacon timestamp
-                    await hre.ethers.provider.send('evm_setNextBlockTimestamp', [timestamp + 24 * 60 * 60]);
-                    await hre.ethers.provider.send('evm_mine');
+                    await setBeacon(templateId, 0, timestamp);
+                    // beaconUpdateSubscriptionConditionParameters is 10%
+                    // 0 -> 1 doesn't satisfy the condition but the initial value is deviation reference,
+                    // so this will always return true
+                    const conditionData = encodeData(1);
                     expect(
                       await dapiServer.callStatic.conditionPspBeaconUpdate(
                         beaconUpdateSubscriptionId,
@@ -1210,36 +1211,56 @@ describe('DapiServer', function () {
                     ).to.equal(true);
                   });
                 });
-                context('It has not been at least heartbeat interval seconds since the last update', function () {
-                  it('returns false', async function () {
-                    // Set the Beacon to 100 first
-                    const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                    await setBeacon(templateId, 100, timestamp);
-                    // beaconUpdateSubscriptionConditionParameters is 10%
-                    // 100 -> 109 doesn't satisfy the condition and returns false
-                    const conditionData = encodeData(109);
-                    expect(
-                      await dapiServer.callStatic.conditionPspBeaconUpdate(
-                        beaconUpdateSubscriptionId,
-                        conditionData,
-                        beaconUpdateSubscriptionConditionParameters
-                      )
-                    ).to.equal(false);
+                context('Initial value is not deviation reference', function () {
+                  context('It has been at least heartbeat interval seconds since the last update', function () {
+                    it('returns true', async function () {
+                      // Set the Beacon to 100 first
+                      const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                      await setBeacon(templateId, 100, timestamp);
+                      // beaconUpdateSubscriptionConditionParameters is 10% and 1 day
+                      // 100 -> 109 doesn't satisfy the condition
+                      const conditionData = encodeData(109);
+                      // It has been 1 day since the Beacon timestamp
+                      await hre.ethers.provider.send('evm_setNextBlockTimestamp', [timestamp + 24 * 60 * 60]);
+                      await hre.ethers.provider.send('evm_mine');
+                      expect(
+                        await dapiServer.callStatic.conditionPspBeaconUpdate(
+                          beaconUpdateSubscriptionId,
+                          conditionData,
+                          beaconUpdateSubscriptionConditionParameters
+                        )
+                      ).to.equal(true);
+                    });
+                  });
+                  context('It has not been at least heartbeat interval seconds since the last update', function () {
+                    it('returns false', async function () {
+                      // Set the Beacon to 100 first
+                      const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                      await setBeacon(templateId, 100, timestamp);
+                      // beaconUpdateSubscriptionConditionParameters is 10%
+                      // 100 -> 109 doesn't satisfy the condition and returns false
+                      const conditionData = encodeData(109);
+                      expect(
+                        await dapiServer.callStatic.conditionPspBeaconUpdate(
+                          beaconUpdateSubscriptionId,
+                          conditionData,
+                          beaconUpdateSubscriptionConditionParameters
+                        )
+                      ).to.equal(false);
+                    });
                   });
                 });
               });
               context('Update is downwards', function () {
-                context('It has been at least heartbeat interval seconds since the last update', function () {
+                context('Initial value is deviation reference', function () {
                   it('returns true', async function () {
-                    // Set the Beacon to 100 first
+                    // Set the Beacon to 0 first
                     const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                    await setBeacon(templateId, 100, timestamp);
-                    // beaconUpdateSubscriptionConditionParameters is 10% and 1 day
-                    // 100 -> 91 doesn't satisfy the condition
-                    const conditionData = encodeData(91);
-                    // It has been 1 day since the Beacon timestamp
-                    await hre.ethers.provider.send('evm_setNextBlockTimestamp', [timestamp + 24 * 60 * 60]);
-                    await hre.ethers.provider.send('evm_mine');
+                    await setBeacon(templateId, 0, timestamp);
+                    // beaconUpdateSubscriptionConditionParameters is 10%
+                    // 0 -> -1 doesn't satisfy the condition but the initial value is deviation reference,
+                    // so this will always return true
+                    const conditionData = encodeData(-1);
                     expect(
                       await dapiServer.callStatic.conditionPspBeaconUpdate(
                         beaconUpdateSubscriptionId,
@@ -1249,21 +1270,43 @@ describe('DapiServer', function () {
                     ).to.equal(true);
                   });
                 });
-                context('It has not been at least heartbeat interval seconds since the last update', function () {
-                  it('returns false', async function () {
-                    // Set the Beacon to 100 first
-                    const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
-                    await setBeacon(templateId, 100, timestamp);
-                    // beaconUpdateSubscriptionConditionParameters is 10%
-                    // 100 -> 91 doesn't satisfy the condition and returns false
-                    const conditionData = encodeData(91);
-                    expect(
-                      await dapiServer.callStatic.conditionPspBeaconUpdate(
-                        beaconUpdateSubscriptionId,
-                        conditionData,
-                        beaconUpdateSubscriptionConditionParameters
-                      )
-                    ).to.equal(false);
+                context('Initial value is not deviation reference', function () {
+                  context('It has been at least heartbeat interval seconds since the last update', function () {
+                    it('returns true', async function () {
+                      // Set the Beacon to 100 first
+                      const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                      await setBeacon(templateId, 100, timestamp);
+                      // beaconUpdateSubscriptionConditionParameters is 10% and 1 day
+                      // 100 -> 91 doesn't satisfy the condition
+                      const conditionData = encodeData(91);
+                      // It has been 1 day since the Beacon timestamp
+                      await hre.ethers.provider.send('evm_setNextBlockTimestamp', [timestamp + 24 * 60 * 60]);
+                      await hre.ethers.provider.send('evm_mine');
+                      expect(
+                        await dapiServer.callStatic.conditionPspBeaconUpdate(
+                          beaconUpdateSubscriptionId,
+                          conditionData,
+                          beaconUpdateSubscriptionConditionParameters
+                        )
+                      ).to.equal(true);
+                    });
+                  });
+                  context('It has not been at least heartbeat interval seconds since the last update', function () {
+                    it('returns false', async function () {
+                      // Set the Beacon to 100 first
+                      const timestamp = (await testUtils.getCurrentTimestamp(hre.ethers.provider)) + 1;
+                      await setBeacon(templateId, 100, timestamp);
+                      // beaconUpdateSubscriptionConditionParameters is 10%
+                      // 100 -> 91 doesn't satisfy the condition and returns false
+                      const conditionData = encodeData(91);
+                      expect(
+                        await dapiServer.callStatic.conditionPspBeaconUpdate(
+                          beaconUpdateSubscriptionId,
+                          conditionData,
+                          beaconUpdateSubscriptionConditionParameters
+                        )
+                      ).to.equal(false);
+                    });
                   });
                 });
               });


### PR DESCRIPTION
I added a new condition parameter, `deviationReference`, which implicitly was `0` in the previous implementation. How to use it:
- If you want to set up a traditional price data feed and replicate the existing Beacons, set it to 0
- If you want to set up a signed temperature data feed in Celsius with 18 decimals, set it to `-273 * 10^18` and choose a deviation threshold that satisfies your deviation characteristics
- If you want to set up a 18 decimal temperature of ocean data feed that is expected to be between 0 and 100 Celsius degrees, you can still set `deviationReference` to `-100 * 10^18` to prevent it from freaking out when it's near 0

This is nicer than https://github.com/api3dao/airnode-protocol-v1/pull/46 because the user of signed data only needs to know the number of decimals, the deviation normalizing parameters will be transparent to them.