### PR TITLE
Add ProxyFactory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install dependencies
+        run: yarn
+      - name: Run unit tests
+        run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,7 @@ jobs:
           node-version: '14'
       - name: Install dependencies
         run: yarn
+      - name: Lint
+        run: yarn lint
       - name: Run unit tests
         run: yarn test

--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -15,7 +15,6 @@ contract DapiProxy is IDapiProxy {
     function read()
         external
         view
-        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -3,15 +3,38 @@ pragma solidity ^0.8.0;
 
 import "./interfaces/IDapiProxy.sol";
 
+/// @title An immutable proxy contract that is used to read a specific dAPI of
+/// a specific DapiServer contract
+/// @dev The proxy contracts are generalized to support most types of numerical
+/// data feeds. This means that the user of this proxy is expected to validate
+/// the read values according to the specific use-case. For example, `value` is
+/// a signed integer, yet it being negative may not make sense in the case that
+/// the data feed represents the spot price of an asset. In that case, the user
+/// is responsible with ensuring that `value` is not negative.
+/// `timestamp` is derived from the system times of the Airnodes that signed
+/// the data that contributed to the most recent update (which is not equal to
+/// the block time of the most recent update). Its main function is to prevent
+/// out of date values from being used to update data feeds. If you will be
+/// implementing a contract that uses `timestamp` in the contract logic in any
+/// way (e.g., reject readings with `timestamp` that is more than 1 day old),
+/// make sure to refer to DapiServer.sol and understand how this number is
+/// derived.
 contract DapiProxy is IDapiProxy {
+    /// @notice DapiServer address
     address public immutable override dapiServer;
+    /// @notice Hash of the dAPI name
     bytes32 public immutable override dapiNameHash;
 
+    /// @param _dapiServer DapiServer address
+    /// @param _dapiName dAPI name
     constructor(address _dapiServer, bytes32 _dapiName) {
         dapiServer = _dapiServer;
         dapiNameHash = keccak256(abi.encodePacked(_dapiName));
     }
 
+    /// @notice Reads the dAPI that this proxy maps to
+    /// @return value dAPI value
+    /// @return timestamp dAPI timestamp
     function read()
         external
         view

--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -38,6 +38,7 @@ contract DapiProxy is IDapiProxy {
     function read()
         external
         view
+        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/DapiProxyWithOev.sol
+++ b/contracts/dapis/proxies/DapiProxyWithOev.sol
@@ -1,31 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./interfaces/IDapiProxy.sol";
+import "./DapiProxy.sol";
 import "./interfaces/IOevUpdater.sol";
 
 /// @title An immutable proxy contract that is used to read a specific dAPI of
 /// a specific DapiServer contract, execute OEV updates and let the beneficiary
 /// withdraw the accumulated proceeds
-/// @dev The proxy contracts are generalized to support most types of numerical
-/// data feeds. This means that the user of this proxy is expected to validate
-/// the read values according to the specific use-case. For example, `value` is
-/// a signed integer, yet it being negative may not make sense in the case that
-/// the data feed represents the spot price of an asset. In that case, the user
-/// is responsible with ensuring that `value` is not negative.
-/// `timestamp` is derived from the system times of the Airnodes that signed
-/// the data that contributed to the most recent update (which is not equal to
-/// the block time of the most recent update). Its main function is to prevent
-/// out of date values from being used to update data feeds. If you will be
-/// implementing a contract that uses `timestamp` in the contract logic in any
-/// way (e.g., reject readings with `timestamp` that is more than 1 day old),
-/// make sure to refer to DapiServer.sol and understand how this number is
-/// derived.
-contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
-    /// @notice DapiServer address
-    address public immutable override dapiServer;
-    /// @notice Hash of the dAPI name
-    bytes32 public immutable override dapiNameHash;
+/// @dev See DapiProxy.sol for comments about usage
+contract DapiProxyWithOev is DapiProxy, IOevUpdater {
     /// @notice OEV beneficiary address
     address public immutable override oevBeneficiary;
 
@@ -36,9 +19,7 @@ contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
         address _dapiServer,
         bytes32 _dapiName,
         address _oevBeneficiary
-    ) {
-        dapiServer = _dapiServer;
-        dapiNameHash = keccak256(abi.encodePacked(_dapiName));
+    ) DapiProxy(_dapiServer, _dapiName) {
         oevBeneficiary = _oevBeneficiary;
     }
 
@@ -137,6 +118,7 @@ contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
     function read()
         external
         view
+        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/DapiProxyWithOev.sol
+++ b/contracts/dapis/proxies/DapiProxyWithOev.sol
@@ -4,11 +4,34 @@ pragma solidity ^0.8.0;
 import "./interfaces/IDapiProxy.sol";
 import "./interfaces/IOevUpdater.sol";
 
+/// @title An immutable proxy contract that is used to read a specific dAPI of
+/// a specific DapiServer contract, execute OEV updates and let the beneficiary
+/// withdraw the accumulated proceeds
+/// @dev The proxy contracts are generalized to support most types of numerical
+/// data feeds. This means that the user of this proxy is expected to validate
+/// the read values according to the specific use-case. For example, `value` is
+/// a signed integer, yet it being negative may not make sense in the case that
+/// the data feed represents the spot price of an asset. In that case, the user
+/// is responsible with ensuring that `value` is not negative.
+/// `timestamp` is derived from the system times of the Airnodes that signed
+/// the data that contributed to the most recent update (which is not equal to
+/// the block time of the most recent update). Its main function is to prevent
+/// out of date values from being used to update data feeds. If you will be
+/// implementing a contract that uses `timestamp` in the contract logic in any
+/// way (e.g., reject readings with `timestamp` that is more than 1 day old),
+/// make sure to refer to DapiServer.sol and understand how this number is
+/// derived.
 contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
+    /// @notice DapiServer address
     address public immutable override dapiServer;
+    /// @notice Hash of the dAPI name
     bytes32 public immutable override dapiNameHash;
+    /// @notice OEV beneficiary address
     address public immutable override oevBeneficiary;
 
+    /// @param _dapiServer DapiServer address
+    /// @param _dapiName dAPI name
+    /// @param _oevBeneficiary OEV beneficiary
     constructor(
         address _dapiServer,
         bytes32 _dapiName,
@@ -19,6 +42,8 @@ contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
         oevBeneficiary = _oevBeneficiary;
     }
 
+    /// @notice Called by anyone to withdraw the OEV proceeds to the
+    /// beneficiary account
     function withdraw() external override {
         uint256 balance = address(this).balance;
         require(balance > 0, "Zero balance");
@@ -27,16 +52,28 @@ contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
         require(success, "Beneficiary reverted withdrawal");
     }
 
+    /// @notice Called by the OEV auction winner along with the bid payment to
+    /// update the OEV proxy Beacon
+    /// @dev The winner of the auction calls this in a `multicall()` and
+    /// extracts the OEV in subsequent calls of the same transaction
+    /// @param airnode Airnode address
+    /// @param templateId Template ID
+    /// @param timestamp Timestamp used in the signature
+    /// @param data Response data (an `int256` encoded in contract ABI)
+    /// @param expirationTimestamp Expiration timestamp of the signature
+    /// @param bidAmount Amount of the bid that won the OEV auction
+    /// @param signature Template ID, a timestamp and the response data signed
+    /// for the specific bid by the Airnode address
     function updateOevProxyBeaconWithSignedData(
         address airnode,
         bytes32 templateId,
         uint256 timestamp,
         bytes memory data,
-        uint256 expireTimestamp,
+        uint256 expirationTimestamp,
         uint256 bidAmount,
         bytes memory signature
     ) external payable override {
-        require(block.timestamp < expireTimestamp, "Expired signature");
+        require(block.timestamp < expirationTimestamp, "Expired signature");
         require(msg.value == bidAmount, "Invalid bid amount");
         IDapiServer(dapiServer).updateOevProxyBeaconWithSignedData(
             airnode,
@@ -47,23 +84,36 @@ contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
                 block.chainid,
                 address(this),
                 msg.sender,
-                expireTimestamp,
+                expirationTimestamp,
                 bidAmount
             ),
             signature
         );
     }
 
+    /// @notice Called by the OEV auction winner along with the bid payment to
+    /// update the OEV proxy Beacon set
+    /// @dev The winner of the auction calls this in a `multicall()` and
+    /// extracts the OEV in subsequent calls of the same transaction
+    /// @param airnodes Airnode addresses
+    /// @param templateIds Template IDs
+    /// @param timestamps Timestamps used in the signatures
+    /// @param data Response data (an `int256` encoded in contract ABI per
+    /// Beacon)
+    /// @param expirationTimestamp Expiration timestamp of the signatures
+    /// @param bidAmount Amount of the bid that won the OEV auction
+    /// @param signatures Template ID, a timestamp and the response data signed
+    /// for the specific bid by the respective Airnode address per Beacon
     function updateOevProxyBeaconSetWithSignedData(
         address[] memory airnodes,
         bytes32[] memory templateIds,
         uint256[] memory timestamps,
         bytes[] memory data,
-        uint256 expireTimestamp,
+        uint256 expirationTimestamp,
         uint256 bidAmount,
         bytes[] memory signatures
     ) external payable override {
-        require(block.timestamp < expireTimestamp, "Expired signature");
+        require(block.timestamp < expirationTimestamp, "Expired signature");
         require(msg.value == bidAmount, "Invalid bid amount");
         IDapiServer(dapiServer).updateOevProxyBeaconSetWithSignedData(
             airnodes,
@@ -74,13 +124,16 @@ contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
                 block.chainid,
                 address(this),
                 msg.sender,
-                expireTimestamp,
+                expirationTimestamp,
                 bidAmount
             ),
             signatures
         );
     }
 
+    /// @notice Reads the dAPI that this proxy maps to
+    /// @return value dAPI value
+    /// @return timestamp dAPI timestamp
     function read()
         external
         view

--- a/contracts/dapis/proxies/DapiProxyWithOev.sol
+++ b/contracts/dapis/proxies/DapiProxyWithOev.sol
@@ -84,7 +84,6 @@ contract DapiProxyWithOev is IDapiProxy, IOevUpdater {
     function read()
         external
         view
-        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/DataFeedProxy.sol
+++ b/contracts/dapis/proxies/DataFeedProxy.sol
@@ -15,7 +15,6 @@ contract DataFeedProxy is IDataFeedProxy {
     function read()
         external
         view
-        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/DataFeedProxy.sol
+++ b/contracts/dapis/proxies/DataFeedProxy.sol
@@ -38,6 +38,7 @@ contract DataFeedProxy is IDataFeedProxy {
     function read()
         external
         view
+        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/DataFeedProxy.sol
+++ b/contracts/dapis/proxies/DataFeedProxy.sol
@@ -3,15 +3,38 @@ pragma solidity ^0.8.0;
 
 import "./interfaces/IDataFeedProxy.sol";
 
+/// @title An immutable proxy contract that is used to read a specific data
+/// feed (Beacon or Beacon set) of a specific DapiServer contract
+/// @dev The proxy contracts are generalized to support most types of numerical
+/// data feeds. This means that the user of this proxy is expected to validate
+/// the read values according to the specific use-case. For example, `value` is
+/// a signed integer, yet it being negative may not make sense in the case that
+/// the data feed represents the spot price of an asset. In that case, the user
+/// is responsible with ensuring that `value` is not negative.
+/// `timestamp` is derived from the system times of the Airnodes that signed
+/// the data that contributed to the most recent update (which is not equal to
+/// the block time of the most recent update). Its main function is to prevent
+/// out of date values from being used to update data feeds. If you will be
+/// implementing a contract that uses `timestamp` in the contract logic in any
+/// way (e.g., reject readings with `timestamp` that is more than 1 day old),
+/// make sure to refer to DapiServer.sol and understand how this number is
+/// derived.
 contract DataFeedProxy is IDataFeedProxy {
+    /// @notice DapiServer address
     address public immutable override dapiServer;
+    /// @notice Data feed ID
     bytes32 public immutable override dataFeedId;
 
+    /// @param _dapiServer DapiServer address
+    /// @param _dataFeedId Data feed (Beacon or Beacon set) ID
     constructor(address _dapiServer, bytes32 _dataFeedId) {
         dapiServer = _dapiServer;
         dataFeedId = _dataFeedId;
     }
 
+    /// @notice Reads the data feed that this proxy maps to
+    /// @return value Data feed value
+    /// @return timestamp Data feed timestamp
     function read()
         external
         view

--- a/contracts/dapis/proxies/DataFeedProxyWithOev.sol
+++ b/contracts/dapis/proxies/DataFeedProxyWithOev.sol
@@ -4,11 +4,34 @@ pragma solidity ^0.8.0;
 import "./interfaces/IDataFeedProxy.sol";
 import "./interfaces/IOevUpdater.sol";
 
+/// @title An immutable proxy contract that is used to read a specific data
+/// feed (Beacon or Beacon set) of a specific DapiServer contract, execute OEV
+/// updates and let the beneficiary withdraw the accumulated proceeds
+/// @dev The proxy contracts are generalized to support most types of numerical
+/// data feeds. This means that the user of this proxy is expected to validate
+/// the read values according to the specific use-case. For example, `value` is
+/// a signed integer, yet it being negative may not make sense in the case that
+/// the data feed represents the spot price of an asset. In that case, the user
+/// is responsible with ensuring that `value` is not negative.
+/// `timestamp` is derived from the system times of the Airnodes that signed
+/// the data that contributed to the most recent update (which is not equal to
+/// the block time of the most recent update). Its main function is to prevent
+/// out of date values from being used to update data feeds. If you will be
+/// implementing a contract that uses `timestamp` in the contract logic in any
+/// way (e.g., reject readings with `timestamp` that is more than 1 day old),
+/// make sure to refer to DapiServer.sol and understand how this number is
+/// derived.
 contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
+    /// @notice DapiServer address
     address public immutable override dapiServer;
+    /// @notice Data feed ID
     bytes32 public immutable override dataFeedId;
+    /// @notice OEV beneficiary address
     address public immutable override oevBeneficiary;
 
+    /// @param _dapiServer DapiServer address
+    /// @param _dataFeedId Data feed (Beacon or Beacon set) ID
+    /// @param _oevBeneficiary OEV beneficiary
     constructor(
         address _dapiServer,
         bytes32 _dataFeedId,
@@ -19,6 +42,8 @@ contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
         oevBeneficiary = _oevBeneficiary;
     }
 
+    /// @notice Called by anyone to withdraw the OEV proceeds to the
+    /// beneficiary account
     function withdraw() external {
         uint256 balance = address(this).balance;
         require(balance > 0, "Zero balance");
@@ -27,16 +52,28 @@ contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
         require(success, "Beneficiary reverted withdrawal");
     }
 
+    /// @notice Called by the OEV auction winner along with the bid payment to
+    /// update the OEV proxy Beacon
+    /// @dev The winner of the auction calls this in a `multicall()` and
+    /// extracts the OEV in subsequent calls of the same transaction
+    /// @param airnode Airnode address
+    /// @param templateId Template ID
+    /// @param timestamp Timestamp used in the signature
+    /// @param data Response data (an `int256` encoded in contract ABI)
+    /// @param expirationTimestamp Expiration timestamp of the signature
+    /// @param bidAmount Amount of the bid that won the OEV auction
+    /// @param signature Template ID, a timestamp and the response data signed
+    /// for the specific bid by the Airnode address
     function updateOevProxyBeaconWithSignedData(
         address airnode,
         bytes32 templateId,
         uint256 timestamp,
         bytes memory data,
-        uint256 expireTimestamp,
+        uint256 expirationTimestamp,
         uint256 bidAmount,
         bytes memory signature
     ) external payable {
-        require(block.timestamp < expireTimestamp, "Expired signature");
+        require(block.timestamp < expirationTimestamp, "Expired signature");
         require(msg.value == bidAmount, "Invalid bid amount");
         IDapiServer(dapiServer).updateOevProxyBeaconWithSignedData(
             airnode,
@@ -47,23 +84,36 @@ contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
                 block.chainid,
                 address(this),
                 msg.sender,
-                expireTimestamp,
+                expirationTimestamp,
                 bidAmount
             ),
             signature
         );
     }
 
+    /// @notice Called by the OEV auction winner along with the bid payment to
+    /// update the OEV proxy Beacon set
+    /// @dev The winner of the auction calls this in a `multicall()` and
+    /// extracts the OEV in subsequent calls of the same transaction
+    /// @param airnodes Airnode addresses
+    /// @param templateIds Template IDs
+    /// @param timestamps Timestamps used in the signatures
+    /// @param data Response data (an `int256` encoded in contract ABI per
+    /// Beacon)
+    /// @param expirationTimestamp Expiration timestamp of the signatures
+    /// @param bidAmount Amount of the bid that won the OEV auction
+    /// @param signatures Template ID, a timestamp and the response data signed
+    /// for the specific bid by the respective Airnode address per Beacon
     function updateOevProxyBeaconSetWithSignedData(
         address[] memory airnodes,
         bytes32[] memory templateIds,
         uint256[] memory timestamps,
         bytes[] memory data,
-        uint256 expireTimestamp,
+        uint256 expirationTimestamp,
         uint256 bidAmount,
         bytes[] memory signatures
     ) external payable {
-        require(block.timestamp < expireTimestamp, "Expired signature");
+        require(block.timestamp < expirationTimestamp, "Expired signature");
         require(msg.value == bidAmount, "Invalid bid amount");
         IDapiServer(dapiServer).updateOevProxyBeaconSetWithSignedData(
             airnodes,
@@ -74,13 +124,16 @@ contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
                 block.chainid,
                 address(this),
                 msg.sender,
-                expireTimestamp,
+                expirationTimestamp,
                 bidAmount
             ),
             signatures
         );
     }
 
+    /// @notice Reads the data feed that this proxy maps to
+    /// @return value Data feed value
+    /// @return timestamp Data feed timestamp
     function read()
         external
         view

--- a/contracts/dapis/proxies/DataFeedProxyWithOev.sol
+++ b/contracts/dapis/proxies/DataFeedProxyWithOev.sol
@@ -1,31 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./interfaces/IDataFeedProxy.sol";
+import "./DataFeedProxy.sol";
 import "./interfaces/IOevUpdater.sol";
 
 /// @title An immutable proxy contract that is used to read a specific data
 /// feed (Beacon or Beacon set) of a specific DapiServer contract, execute OEV
 /// updates and let the beneficiary withdraw the accumulated proceeds
-/// @dev The proxy contracts are generalized to support most types of numerical
-/// data feeds. This means that the user of this proxy is expected to validate
-/// the read values according to the specific use-case. For example, `value` is
-/// a signed integer, yet it being negative may not make sense in the case that
-/// the data feed represents the spot price of an asset. In that case, the user
-/// is responsible with ensuring that `value` is not negative.
-/// `timestamp` is derived from the system times of the Airnodes that signed
-/// the data that contributed to the most recent update (which is not equal to
-/// the block time of the most recent update). Its main function is to prevent
-/// out of date values from being used to update data feeds. If you will be
-/// implementing a contract that uses `timestamp` in the contract logic in any
-/// way (e.g., reject readings with `timestamp` that is more than 1 day old),
-/// make sure to refer to DapiServer.sol and understand how this number is
-/// derived.
-contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
-    /// @notice DapiServer address
-    address public immutable override dapiServer;
-    /// @notice Data feed ID
-    bytes32 public immutable override dataFeedId;
+/// @dev See DapiProxy.sol for comments about usage
+contract DataFeedProxyWithOev is DataFeedProxy, IOevUpdater {
     /// @notice OEV beneficiary address
     address public immutable override oevBeneficiary;
 
@@ -36,9 +19,7 @@ contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
         address _dapiServer,
         bytes32 _dataFeedId,
         address _oevBeneficiary
-    ) {
-        dapiServer = _dapiServer;
-        dataFeedId = _dataFeedId;
+    ) DataFeedProxy(_dapiServer, _dataFeedId) {
         oevBeneficiary = _oevBeneficiary;
     }
 
@@ -137,6 +118,7 @@ contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
     function read()
         external
         view
+        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/DataFeedProxyWithOev.sol
+++ b/contracts/dapis/proxies/DataFeedProxyWithOev.sol
@@ -84,7 +84,6 @@ contract DataFeedProxyWithOev is IDataFeedProxy, IOevUpdater {
     function read()
         external
         view
-        virtual
         override
         returns (int224 value, uint32 timestamp)
     {

--- a/contracts/dapis/proxies/ProxyFactory.sol
+++ b/contracts/dapis/proxies/ProxyFactory.sol
@@ -5,66 +5,64 @@ import "./DataFeedProxy.sol";
 import "./DapiProxy.sol";
 import "./DataFeedProxyWithOev.sol";
 import "./DapiProxyWithOev.sol";
+import "./interfaces/IProxyFactory.sol";
 
-contract ProxyFactory {
-    event DeployedDataFeedProxy(
-        address indexed proxyAddress,
-        bytes32 indexed dataFeedId,
-        bytes metadata
-    );
+/// @title Contract factory that deterministically deploys proxies that read
+/// data feeds (Beacons or Beacon sets) or dAPIs, along with optional OEV
+/// support
+/// @dev The proxies are deployed normally and not cloned to minimize the gas
+/// cost overhead while using them to read data feed values.
+contract ProxyFactory is IProxyFactory {
+    /// @notice DapiServer address
+    address public immutable override dapiServer;
 
-    event DeployedDapiProxy(
-        address indexed proxyAddress,
-        bytes32 indexed dapiName,
-        bytes metadata
-    );
-
-    event DeployedDataFeedProxyWithOev(
-        address indexed proxyAddress,
-        bytes32 indexed dataFeedId,
-        address indexed oevBeneficiary,
-        bytes metadata
-    );
-
-    event DeployedDapiProxyWithOev(
-        address indexed proxyAddress,
-        bytes32 indexed dapiName,
-        address indexed oevBeneficiary,
-        bytes metadata
-    );
-
-    address public immutable dapiServer;
-
+    /// @param _dapiServer DapiServer address
     constructor(address _dapiServer) {
-        require(_dapiServer != address(0), "dAPI server zero");
+        require(_dapiServer != address(0), "DapiServer address zero");
         dapiServer = _dapiServer;
     }
 
+    /// @notice Deterministically deploys a data feed proxy
+    /// @param dataFeedId Data feed ID
+    /// @param metadata Metadata associated with the proxy
     function deployDataFeedProxy(bytes32 dataFeedId, bytes calldata metadata)
         external
+        override
         returns (address proxyAddress)
     {
+        require(dataFeedId != bytes32(0), "Data feed ID zero");
         proxyAddress = address(
             new DataFeedProxy{salt: keccak256(metadata)}(dapiServer, dataFeedId)
         );
         emit DeployedDataFeedProxy(proxyAddress, dataFeedId, metadata);
     }
 
+    /// @notice Deterministically deploys a dAPI proxy
+    /// @param dapiName dAPI name
+    /// @param metadata Metadata associated with the proxy
     function deployDapiProxy(bytes32 dapiName, bytes calldata metadata)
         external
+        override
         returns (address proxyAddress)
     {
+        require(dapiName != bytes32(0), "dAPI name zero");
         proxyAddress = address(
             new DapiProxy{salt: keccak256(metadata)}(dapiServer, dapiName)
         );
         emit DeployedDapiProxy(proxyAddress, dapiName, metadata);
     }
 
+    /// @notice Deterministically deploys a data feed proxy with OEV support
+    /// @param dataFeedId Data feed ID
+    /// @param oevBeneficiary OEV beneficiary
+    /// @param metadata Metadata associated with the proxy
     function deployDataFeedProxyWithOev(
         bytes32 dataFeedId,
         address oevBeneficiary,
         bytes calldata metadata
-    ) external returns (address proxyAddress) {
+    ) external override returns (address proxyAddress) {
+        require(dataFeedId != bytes32(0), "Data feed ID zero");
+        require(oevBeneficiary != address(0), "OEV beneficiary zero");
         proxyAddress = address(
             new DataFeedProxyWithOev{salt: keccak256(metadata)}(
                 dapiServer,
@@ -80,11 +78,17 @@ contract ProxyFactory {
         );
     }
 
+    /// @notice Deterministically deploys a dAPI proxy with OEV support
+    /// @param dapiName dAPI name
+    /// @param oevBeneficiary OEV beneficiary
+    /// @param metadata Metadata associated with the proxy
     function deployDapiProxyWithOev(
         bytes32 dapiName,
         address oevBeneficiary,
         bytes calldata metadata
-    ) external returns (address proxyAddress) {
+    ) external override returns (address proxyAddress) {
+        require(dapiName != bytes32(0), "dAPI name zero");
+        require(oevBeneficiary != address(0), "OEV beneficiary zero");
         proxyAddress = address(
             new DapiProxyWithOev{salt: keccak256(metadata)}(
                 dapiServer,

--- a/contracts/dapis/proxies/ProxyFactory.sol
+++ b/contracts/dapis/proxies/ProxyFactory.sol
@@ -48,9 +48,15 @@ contract ProxyFactory {
             type(DataFeedProxy).creationCode,
             abi.encode(dapiServer, dataFeedId)
         );
+        bytes32 metadataHash = keccak256(metadata);
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+            proxyAddress := create2(
+                0,
+                add(initcode, 0x20),
+                mload(initcode),
+                metadataHash
+            )
         }
         require(proxyAddress != address(0), "Proxy already deployed");
         emit DeployedDataFeedProxy(proxyAddress, dataFeedId, metadata);
@@ -64,9 +70,15 @@ contract ProxyFactory {
             type(DapiProxy).creationCode,
             abi.encode(dapiServer, dapiName)
         );
+        bytes32 metadataHash = keccak256(metadata);
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+            proxyAddress := create2(
+                0,
+                add(initcode, 0x20),
+                mload(initcode),
+                metadataHash
+            )
         }
         require(proxyAddress != address(0), "Proxy already deployed");
         emit DeployedDapiProxy(proxyAddress, dapiName, metadata);
@@ -81,9 +93,15 @@ contract ProxyFactory {
             type(DataFeedProxyWithOev).creationCode,
             abi.encode(dapiServer, dataFeedId, oevBeneficiary)
         );
+        bytes32 metadataHash = keccak256(metadata);
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+            proxyAddress := create2(
+                0,
+                add(initcode, 0x20),
+                mload(initcode),
+                metadataHash
+            )
         }
         require(proxyAddress != address(0), "Proxy already deployed");
         emit DeployedDataFeedProxyWithOev(
@@ -103,9 +121,15 @@ contract ProxyFactory {
             type(DapiProxyWithOev).creationCode,
             abi.encode(dapiServer, dapiName, oevBeneficiary)
         );
+        bytes32 metadataHash = keccak256(metadata);
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+            proxyAddress := create2(
+                0,
+                add(initcode, 0x20),
+                mload(initcode),
+                metadataHash
+            )
         }
         require(proxyAddress != address(0), "Proxy already deployed");
         emit DeployedDapiProxyWithOev(

--- a/contracts/dapis/proxies/ProxyFactory.sol
+++ b/contracts/dapis/proxies/ProxyFactory.sol
@@ -44,21 +44,9 @@ contract ProxyFactory {
         external
         returns (address proxyAddress)
     {
-        bytes memory initcode = abi.encodePacked(
-            type(DataFeedProxy).creationCode,
-            abi.encode(dapiServer, dataFeedId)
+        proxyAddress = address(
+            new DataFeedProxy{salt: keccak256(metadata)}(dapiServer, dataFeedId)
         );
-        bytes32 metadataHash = keccak256(metadata);
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            proxyAddress := create2(
-                0,
-                add(initcode, 0x20),
-                mload(initcode),
-                metadataHash
-            )
-        }
-        require(proxyAddress != address(0), "Proxy already deployed");
         emit DeployedDataFeedProxy(proxyAddress, dataFeedId, metadata);
     }
 
@@ -66,21 +54,9 @@ contract ProxyFactory {
         external
         returns (address proxyAddress)
     {
-        bytes memory initcode = abi.encodePacked(
-            type(DapiProxy).creationCode,
-            abi.encode(dapiServer, dapiName)
+        proxyAddress = address(
+            new DapiProxy{salt: keccak256(metadata)}(dapiServer, dapiName)
         );
-        bytes32 metadataHash = keccak256(metadata);
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            proxyAddress := create2(
-                0,
-                add(initcode, 0x20),
-                mload(initcode),
-                metadataHash
-            )
-        }
-        require(proxyAddress != address(0), "Proxy already deployed");
         emit DeployedDapiProxy(proxyAddress, dapiName, metadata);
     }
 
@@ -89,21 +65,13 @@ contract ProxyFactory {
         address oevBeneficiary,
         bytes calldata metadata
     ) external returns (address proxyAddress) {
-        bytes memory initcode = abi.encodePacked(
-            type(DataFeedProxyWithOev).creationCode,
-            abi.encode(dapiServer, dataFeedId, oevBeneficiary)
-        );
-        bytes32 metadataHash = keccak256(metadata);
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            proxyAddress := create2(
-                0,
-                add(initcode, 0x20),
-                mload(initcode),
-                metadataHash
+        proxyAddress = address(
+            new DataFeedProxyWithOev{salt: keccak256(metadata)}(
+                dapiServer,
+                dataFeedId,
+                oevBeneficiary
             )
-        }
-        require(proxyAddress != address(0), "Proxy already deployed");
+        );
         emit DeployedDataFeedProxyWithOev(
             proxyAddress,
             dataFeedId,
@@ -117,21 +85,13 @@ contract ProxyFactory {
         address oevBeneficiary,
         bytes calldata metadata
     ) external returns (address proxyAddress) {
-        bytes memory initcode = abi.encodePacked(
-            type(DapiProxyWithOev).creationCode,
-            abi.encode(dapiServer, dapiName, oevBeneficiary)
-        );
-        bytes32 metadataHash = keccak256(metadata);
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            proxyAddress := create2(
-                0,
-                add(initcode, 0x20),
-                mload(initcode),
-                metadataHash
+        proxyAddress = address(
+            new DapiProxyWithOev{salt: keccak256(metadata)}(
+                dapiServer,
+                dapiName,
+                oevBeneficiary
             )
-        }
-        require(proxyAddress != address(0), "Proxy already deployed");
+        );
         emit DeployedDapiProxyWithOev(
             proxyAddress,
             dapiName,

--- a/contracts/dapis/proxies/ProxyFactory.sol
+++ b/contracts/dapis/proxies/ProxyFactory.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./DataFeedProxy.sol";
+import "./DapiProxy.sol";
+import "./DataFeedProxyWithOev.sol";
+import "./DapiProxyWithOev.sol";
+
+contract ProxyFactory {
+    event DeployedDataFeedProxy(
+        address indexed proxyAddress,
+        bytes32 indexed dataFeedId,
+        bytes metadata
+    );
+
+    event DeployedDapiProxy(
+        address indexed proxyAddress,
+        bytes32 indexed dapiName,
+        bytes metadata
+    );
+
+    event DeployedDataFeedProxyWithOev(
+        address indexed proxyAddress,
+        bytes32 indexed dataFeedId,
+        address indexed oevBeneficiary,
+        bytes metadata
+    );
+
+    event DeployedDapiProxyWithOev(
+        address indexed proxyAddress,
+        bytes32 indexed dapiName,
+        address indexed oevBeneficiary,
+        bytes metadata
+    );
+
+    address public immutable dapiServer;
+
+    constructor(address _dapiServer) {
+        require(_dapiServer != address(0), "dAPI server zero");
+        dapiServer = _dapiServer;
+    }
+
+    function deployDataFeedProxy(bytes32 dataFeedId, bytes calldata metadata)
+        external
+        returns (address proxyAddress)
+    {
+        bytes memory initcode = abi.encodePacked(
+            type(DataFeedProxy).creationCode,
+            abi.encode(dapiServer, dataFeedId)
+        );
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+        }
+        require(proxyAddress != address(0), "Proxy already deployed");
+        emit DeployedDataFeedProxy(proxyAddress, dataFeedId, metadata);
+    }
+
+    function deployDapiProxy(bytes32 dapiName, bytes calldata metadata)
+        external
+        returns (address proxyAddress)
+    {
+        bytes memory initcode = abi.encodePacked(
+            type(DapiProxy).creationCode,
+            abi.encode(dapiServer, dapiName)
+        );
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+        }
+        require(proxyAddress != address(0), "Proxy already deployed");
+        emit DeployedDapiProxy(proxyAddress, dapiName, metadata);
+    }
+
+    function deployDataFeedProxyWithOev(
+        bytes32 dataFeedId,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external returns (address proxyAddress) {
+        bytes memory initcode = abi.encodePacked(
+            type(DataFeedProxyWithOev).creationCode,
+            abi.encode(dapiServer, dataFeedId, oevBeneficiary)
+        );
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+        }
+        require(proxyAddress != address(0), "Proxy already deployed");
+        emit DeployedDataFeedProxyWithOev(
+            proxyAddress,
+            dataFeedId,
+            oevBeneficiary,
+            metadata
+        );
+    }
+
+    function deployDapiProxyWithOev(
+        bytes32 dapiName,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external returns (address proxyAddress) {
+        bytes memory initcode = abi.encodePacked(
+            type(DapiProxyWithOev).creationCode,
+            abi.encode(dapiServer, dapiName, oevBeneficiary)
+        );
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            proxyAddress := create2(0, add(initcode, 0x20), mload(initcode), 0)
+        }
+        require(proxyAddress != address(0), "Proxy already deployed");
+        emit DeployedDapiProxyWithOev(
+            proxyAddress,
+            dapiName,
+            oevBeneficiary,
+            metadata
+        );
+    }
+}

--- a/contracts/dapis/proxies/interfaces/IProxyFactory.sol
+++ b/contracts/dapis/proxies/interfaces/IProxyFactory.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IProxyFactory {
+    event DeployedDataFeedProxy(
+        address indexed proxyAddress,
+        bytes32 indexed dataFeedId,
+        bytes metadata
+    );
+
+    event DeployedDapiProxy(
+        address indexed proxyAddress,
+        bytes32 indexed dapiName,
+        bytes metadata
+    );
+
+    event DeployedDataFeedProxyWithOev(
+        address indexed proxyAddress,
+        bytes32 indexed dataFeedId,
+        address indexed oevBeneficiary,
+        bytes metadata
+    );
+
+    event DeployedDapiProxyWithOev(
+        address indexed proxyAddress,
+        bytes32 indexed dapiName,
+        address indexed oevBeneficiary,
+        bytes metadata
+    );
+
+    function deployDataFeedProxy(bytes32 dataFeedId, bytes calldata metadata)
+        external
+        returns (address proxyAddress);
+
+    function deployDapiProxy(bytes32 dapiName, bytes calldata metadata)
+        external
+        returns (address proxyAddress);
+
+    function deployDataFeedProxyWithOev(
+        bytes32 dataFeedId,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external returns (address proxyAddress);
+
+    function deployDapiProxyWithOev(
+        bytes32 dapiName,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external returns (address proxyAddress);
+
+    function dapiServer() external view returns (address);
+}

--- a/test/dapis/proxies/ProxyFactory.sol.js
+++ b/test/dapis/proxies/ProxyFactory.sol.js
@@ -67,14 +67,14 @@ describe('ProxyFactory', function () {
           hre.ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [dapiServer.address, beaconId]),
         ]
       );
+      // metadata includes information like policy hash, commission recipient, etc.
+      const metadata = testUtils.generateRandomBytes();
       const proxyAddress = hre.ethers.utils.getCreate2Address(
         proxyFactory.address,
-        hre.ethers.constants.HashZero,
+        hre.ethers.utils.keccak256(metadata),
         hre.ethers.utils.keccak256(initcode)
       );
 
-      // metadata includes information like policy hash, commission recipient, etc.
-      const metadata = testUtils.generateRandomBytes();
       // Can only deploy once
       await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata))
         .to.emit(proxyFactory, 'DeployedDataFeedProxy')

--- a/test/dapis/proxies/ProxyFactory.sol.js
+++ b/test/dapis/proxies/ProxyFactory.sol.js
@@ -80,7 +80,7 @@ describe('ProxyFactory', function () {
         .to.emit(proxyFactory, 'DeployedDataFeedProxy')
         .withArgs(proxyAddress, beaconId, metadata);
       // Subsequent deployments will revert
-      await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata)).to.be.revertedWith('Proxy already deployed');
+      await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata)).to.be.reverted;
 
       // Confirm that the bytecode is the same
       const dataFeedProxyFactory = await hre.ethers.getContractFactory('DataFeedProxy', roles.deployer);

--- a/test/dapis/proxies/ProxyFactory.sol.js
+++ b/test/dapis/proxies/ProxyFactory.sol.js
@@ -14,6 +14,7 @@ describe('ProxyFactory', function () {
     roles = {
       deployer: accounts[0],
       manager: accounts[1],
+      oevBeneficiary: accounts[2],
       randomPerson: accounts[9],
     };
     const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
@@ -56,46 +57,277 @@ describe('ProxyFactory', function () {
     proxyFactory = await proxyFactoryFactory.deploy(dapiServer.address);
   });
 
-  describe('deploy', function () {
-    it('deploys', async function () {
-      // Precompute the proxy address
-      const DataFeedProxy = await hre.artifacts.readArtifact('DataFeedProxy');
-      const initcode = hre.ethers.utils.solidityPack(
-        ['bytes', 'bytes'],
-        [
-          DataFeedProxy.bytecode,
-          hre.ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [dapiServer.address, beaconId]),
-        ]
-      );
-      // metadata includes information like policy hash, commission recipient, etc.
-      const metadata = testUtils.generateRandomBytes();
-      const proxyAddress = hre.ethers.utils.getCreate2Address(
-        proxyFactory.address,
-        hre.ethers.utils.keccak256(metadata),
-        hre.ethers.utils.keccak256(initcode)
-      );
+  describe('constructor', function () {
+    context('DapiServer addres is not zero', function () {
+      it('constructs', async function () {
+        expect(await proxyFactory.dapiServer()).to.equal(dapiServer.address);
+      });
+    });
+    context('DapiServer addres is zero', function () {
+      it('reverts', async function () {
+        const proxyFactoryFactory = await hre.ethers.getContractFactory('ProxyFactory', roles.deployer);
+        await expect(proxyFactoryFactory.deploy(hre.ethers.constants.AddressZero)).to.be.revertedWith(
+          'DapiServer address zero'
+        );
+      });
+    });
+  });
 
-      // Can only deploy once
-      await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata))
-        .to.emit(proxyFactory, 'DeployedDataFeedProxy')
-        .withArgs(proxyAddress, beaconId, metadata);
-      // Subsequent deployments will revert
-      await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata)).to.be.reverted;
+  describe('deployDataFeedProxy', function () {
+    context('Data feed ID is not zero', function () {
+      it('deploys data feed proxy', async function () {
+        // Precompute the proxy address
+        const DataFeedProxy = await hre.artifacts.readArtifact('DataFeedProxy');
+        const initcode = hre.ethers.utils.solidityPack(
+          ['bytes', 'bytes'],
+          [
+            DataFeedProxy.bytecode,
+            hre.ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [dapiServer.address, beaconId]),
+          ]
+        );
+        // metadata includes information like coverage policy ID, etc.
+        const metadata = testUtils.generateRandomBytes();
+        const proxyAddress = hre.ethers.utils.getCreate2Address(
+          proxyFactory.address,
+          hre.ethers.utils.keccak256(metadata),
+          hre.ethers.utils.keccak256(initcode)
+        );
 
-      // Confirm that the bytecode is the same
-      const dataFeedProxyFactory = await hre.ethers.getContractFactory('DataFeedProxy', roles.deployer);
-      const eoaDeployedDataFeedProxy = await dataFeedProxyFactory.deploy(dapiServer.address, beaconId);
-      expect(await hre.ethers.provider.getCode(proxyAddress)).to.equal(
-        await hre.ethers.provider.getCode(eoaDeployedDataFeedProxy.address)
-      );
+        // Can only deploy once
+        await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata))
+          .to.emit(proxyFactory, 'DeployedDataFeedProxy')
+          .withArgs(proxyAddress, beaconId, metadata);
+        // Subsequent deployments will revert with no string
+        await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata)).to.be.reverted;
 
-      // Test the deployed contract
-      const dataFeedProxy = new hre.ethers.Contract(proxyAddress, DataFeedProxy.abi, hre.ethers.provider);
-      expect(await dataFeedProxy.dapiServer()).to.equal(dapiServer.address);
-      expect(await dataFeedProxy.dataFeedId()).to.equal(beaconId);
-      const beacon = await dataFeedProxy.read();
-      expect(beacon.value).to.equal(beaconValue);
-      expect(beacon.timestamp).to.equal(beaconTimestamp);
+        // Confirm that the bytecode is the same
+        const dataFeedProxyFactory = await hre.ethers.getContractFactory('DataFeedProxy', roles.deployer);
+        const eoaDeployedDataFeedProxy = await dataFeedProxyFactory.deploy(dapiServer.address, beaconId);
+        expect(await hre.ethers.provider.getCode(proxyAddress)).to.equal(
+          await hre.ethers.provider.getCode(eoaDeployedDataFeedProxy.address)
+        );
+
+        // Test the deployed contract
+        const dataFeedProxy = new hre.ethers.Contract(proxyAddress, DataFeedProxy.abi, hre.ethers.provider);
+        expect(await dataFeedProxy.dapiServer()).to.equal(dapiServer.address);
+        expect(await dataFeedProxy.dataFeedId()).to.equal(beaconId);
+        const beacon = await dataFeedProxy.read();
+        expect(beacon.value).to.equal(beaconValue);
+        expect(beacon.timestamp).to.equal(beaconTimestamp);
+      });
+    });
+    context('Data feed ID is zero', function () {
+      it('reverts', async function () {
+        const metadata = testUtils.generateRandomBytes();
+        await expect(proxyFactory.deployDataFeedProxy(hre.ethers.constants.HashZero, metadata)).to.be.revertedWith(
+          'Data feed ID zero'
+        );
+      });
+    });
+  });
+
+  describe('deployDapiProxy', function () {
+    context('dAPI name is not zero', function () {
+      it('deploys dAPI proxy', async function () {
+        // Precompute the proxy address
+        const DapiProxy = await hre.artifacts.readArtifact('DapiProxy');
+        const initcode = hre.ethers.utils.solidityPack(
+          ['bytes', 'bytes'],
+          [
+            DapiProxy.bytecode,
+            hre.ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [dapiServer.address, dapiName]),
+          ]
+        );
+        // metadata includes information like coverage policy ID, etc.
+        const metadata = testUtils.generateRandomBytes();
+        const proxyAddress = hre.ethers.utils.getCreate2Address(
+          proxyFactory.address,
+          hre.ethers.utils.keccak256(metadata),
+          hre.ethers.utils.keccak256(initcode)
+        );
+
+        // Can only deploy once
+        await expect(proxyFactory.deployDapiProxy(dapiName, metadata))
+          .to.emit(proxyFactory, 'DeployedDapiProxy')
+          .withArgs(proxyAddress, dapiName, metadata);
+        // Subsequent deployments will revert with no string
+        await expect(proxyFactory.deployDapiProxy(dapiName, metadata)).to.be.reverted;
+
+        // Confirm that the bytecode is the same
+        const dapiProxyFactory = await hre.ethers.getContractFactory('DapiProxy', roles.deployer);
+        const eoaDeployedDapiProxy = await dapiProxyFactory.deploy(dapiServer.address, dapiName);
+        expect(await hre.ethers.provider.getCode(proxyAddress)).to.equal(
+          await hre.ethers.provider.getCode(eoaDeployedDapiProxy.address)
+        );
+
+        // Test the deployed contract
+        const dapiProxy = new hre.ethers.Contract(proxyAddress, DapiProxy.abi, hre.ethers.provider);
+        expect(await dapiProxy.dapiServer()).to.equal(dapiServer.address);
+        expect(await dapiProxy.dapiNameHash()).to.equal(hre.ethers.utils.solidityKeccak256(['bytes32'], [dapiName]));
+        const dapi = await dapiProxy.read();
+        expect(dapi.value).to.equal(beaconValue);
+        expect(dapi.timestamp).to.equal(beaconTimestamp);
+      });
+    });
+    context('dAPI name is zero', function () {
+      it('reverts', async function () {
+        const metadata = testUtils.generateRandomBytes();
+        await expect(proxyFactory.deployDapiProxy(hre.ethers.constants.HashZero, metadata)).to.be.revertedWith(
+          'dAPI name zero'
+        );
+      });
+    });
+  });
+
+  describe('deployDataFeedProxyWithOev', function () {
+    context('Data feed ID is not zero', function () {
+      context('OEV beneficiary is not zero', function () {
+        it('deploys data feed proxy', async function () {
+          // Precompute the proxy address
+          const DataFeedProxyWithOev = await hre.artifacts.readArtifact('DataFeedProxyWithOev');
+          const initcode = hre.ethers.utils.solidityPack(
+            ['bytes', 'bytes'],
+            [
+              DataFeedProxyWithOev.bytecode,
+              hre.ethers.utils.defaultAbiCoder.encode(
+                ['address', 'bytes32', 'address'],
+                [dapiServer.address, beaconId, roles.oevBeneficiary.address]
+              ),
+            ]
+          );
+          // metadata includes information like coverage policy ID, etc.
+          const metadata = testUtils.generateRandomBytes();
+          const proxyAddress = hre.ethers.utils.getCreate2Address(
+            proxyFactory.address,
+            hre.ethers.utils.keccak256(metadata),
+            hre.ethers.utils.keccak256(initcode)
+          );
+
+          // Can only deploy once
+          await expect(proxyFactory.deployDataFeedProxyWithOev(beaconId, roles.oevBeneficiary.address, metadata))
+            .to.emit(proxyFactory, 'DeployedDataFeedProxyWithOev')
+            .withArgs(proxyAddress, beaconId, roles.oevBeneficiary.address, metadata);
+          // Subsequent deployments will revert with no string
+          await expect(
+            proxyFactory.deployDataFeedProxyWithOev(beaconId, roles.oevBeneficiary.address, metadata)
+          ).to.be.reverted;
+
+          // Confirm that the bytecode is the same
+          const dataFeedProxyFactory = await hre.ethers.getContractFactory('DataFeedProxyWithOev', roles.deployer);
+          const eoaDeployedDataFeedProxyWithOev = await dataFeedProxyFactory.deploy(
+            dapiServer.address,
+            beaconId,
+            roles.oevBeneficiary.address
+          );
+          expect(await hre.ethers.provider.getCode(proxyAddress)).to.equal(
+            await hre.ethers.provider.getCode(eoaDeployedDataFeedProxyWithOev.address)
+          );
+
+          // Test the deployed contract
+          const dataFeedProxyWithOev = new hre.ethers.Contract(
+            proxyAddress,
+            DataFeedProxyWithOev.abi,
+            hre.ethers.provider
+          );
+          expect(await dataFeedProxyWithOev.dapiServer()).to.equal(dapiServer.address);
+          expect(await dataFeedProxyWithOev.dataFeedId()).to.equal(beaconId);
+          expect(await dataFeedProxyWithOev.oevBeneficiary()).to.equal(roles.oevBeneficiary.address);
+          const beacon = await dataFeedProxyWithOev.read();
+          expect(beacon.value).to.equal(beaconValue);
+          expect(beacon.timestamp).to.equal(beaconTimestamp);
+        });
+      });
+      context('OEV beneficiary is zero', function () {
+        it('reverts', async function () {
+          const metadata = testUtils.generateRandomBytes();
+          await expect(
+            proxyFactory.deployDataFeedProxyWithOev(beaconId, hre.ethers.constants.AddressZero, metadata)
+          ).to.be.revertedWith('OEV beneficiary zero');
+        });
+      });
+    });
+    context('Data feed ID is zero', function () {
+      it('reverts', async function () {
+        const metadata = testUtils.generateRandomBytes();
+        await expect(
+          proxyFactory.deployDataFeedProxyWithOev(hre.ethers.constants.HashZero, roles.oevBeneficiary.address, metadata)
+        ).to.be.revertedWith('Data feed ID zero');
+      });
+    });
+  });
+
+  describe('deployDapiProxyWithOev', function () {
+    context('Data feed ID is not zero', function () {
+      context('OEV beneficiary is not zero', function () {
+        it('deploys data feed proxy', async function () {
+          // Precompute the proxy address
+          const DapiProxyWithOev = await hre.artifacts.readArtifact('DapiProxyWithOev');
+          const initcode = hre.ethers.utils.solidityPack(
+            ['bytes', 'bytes'],
+            [
+              DapiProxyWithOev.bytecode,
+              hre.ethers.utils.defaultAbiCoder.encode(
+                ['address', 'bytes32', 'address'],
+                [dapiServer.address, dapiName, roles.oevBeneficiary.address]
+              ),
+            ]
+          );
+          // metadata includes information like coverage policy ID, etc.
+          const metadata = testUtils.generateRandomBytes();
+          const proxyAddress = hre.ethers.utils.getCreate2Address(
+            proxyFactory.address,
+            hre.ethers.utils.keccak256(metadata),
+            hre.ethers.utils.keccak256(initcode)
+          );
+
+          // Can only deploy once
+          await expect(proxyFactory.deployDapiProxyWithOev(dapiName, roles.oevBeneficiary.address, metadata))
+            .to.emit(proxyFactory, 'DeployedDapiProxyWithOev')
+            .withArgs(proxyAddress, dapiName, roles.oevBeneficiary.address, metadata);
+          // Subsequent deployments will revert with no string
+          await expect(
+            proxyFactory.deployDapiProxyWithOev(dapiName, roles.oevBeneficiary.address, metadata)
+          ).to.be.reverted;
+
+          // Confirm that the bytecode is the same
+          const dataFeedProxyFactory = await hre.ethers.getContractFactory('DapiProxyWithOev', roles.deployer);
+          const eoaDeployedDapiProxyWithOev = await dataFeedProxyFactory.deploy(
+            dapiServer.address,
+            dapiName,
+            roles.oevBeneficiary.address
+          );
+          expect(await hre.ethers.provider.getCode(proxyAddress)).to.equal(
+            await hre.ethers.provider.getCode(eoaDeployedDapiProxyWithOev.address)
+          );
+
+          // Test the deployed contract
+          const dapiProxyWithOev = new hre.ethers.Contract(proxyAddress, DapiProxyWithOev.abi, hre.ethers.provider);
+          expect(await dapiProxyWithOev.dapiServer()).to.equal(dapiServer.address);
+          expect(await dapiProxyWithOev.dapiNameHash()).to.equal(
+            hre.ethers.utils.solidityKeccak256(['bytes32'], [dapiName])
+          );
+          expect(await dapiProxyWithOev.oevBeneficiary()).to.equal(roles.oevBeneficiary.address);
+          const dapi = await dapiProxyWithOev.read();
+          expect(dapi.value).to.equal(beaconValue);
+          expect(dapi.timestamp).to.equal(beaconTimestamp);
+        });
+      });
+      context('OEV beneficiary is zero', function () {
+        it('reverts', async function () {
+          const metadata = testUtils.generateRandomBytes();
+          await expect(
+            proxyFactory.deployDapiProxyWithOev(beaconId, hre.ethers.constants.AddressZero, metadata)
+          ).to.be.revertedWith('OEV beneficiary zero');
+        });
+      });
+    });
+    context('Data feed ID is zero', function () {
+      it('reverts', async function () {
+        const metadata = testUtils.generateRandomBytes();
+        await expect(
+          proxyFactory.deployDapiProxyWithOev(hre.ethers.constants.HashZero, roles.oevBeneficiary.address, metadata)
+        ).to.be.revertedWith('dAPI name zero');
+      });
     });
   });
 });

--- a/test/dapis/proxies/ProxyFactory.sol.js
+++ b/test/dapis/proxies/ProxyFactory.sol.js
@@ -1,0 +1,101 @@
+const hre = require('hardhat');
+const { expect } = require('chai');
+const testUtils = require('../../test-utils');
+
+describe('ProxyFactory', function () {
+  let roles;
+  let proxyFactory, dapiServer;
+  let dapiServerAdminRoleDescription = 'DapiServer admin';
+  let beaconId, beaconValue, beaconTimestamp;
+  const dapiName = hre.ethers.utils.formatBytes32String('My dAPI');
+
+  beforeEach(async () => {
+    const accounts = await hre.ethers.getSigners();
+    roles = {
+      deployer: accounts[0],
+      manager: accounts[1],
+      randomPerson: accounts[9],
+    };
+    const accessControlRegistryFactory = await hre.ethers.getContractFactory('AccessControlRegistry', roles.deployer);
+    const accessControlRegistry = await accessControlRegistryFactory.deploy();
+    const airnodeProtocolFactory = await hre.ethers.getContractFactory('AirnodeProtocol', roles.deployer);
+    const airnodeProtocol = await airnodeProtocolFactory.deploy();
+    const dapiServerFactory = await hre.ethers.getContractFactory('DapiServer', roles.deployer);
+    dapiServer = await dapiServerFactory.deploy(
+      accessControlRegistry.address,
+      dapiServerAdminRoleDescription,
+      roles.manager.address,
+      airnodeProtocol.address
+    );
+    const airnodeData = testUtils.generateRandomAirnodeWallet();
+    const airnodeAddress = airnodeData.airnodeAddress;
+    const airnodeWallet = hre.ethers.Wallet.fromMnemonic(airnodeData.airnodeMnemonic, "m/44'/60'/0'/0/0");
+    const endpointId = testUtils.generateRandomBytes32();
+    const templateParameters = testUtils.generateRandomBytes();
+    const templateId = hre.ethers.utils.keccak256(
+      hre.ethers.utils.solidityPack(['bytes32', 'bytes'], [endpointId, templateParameters])
+    );
+    beaconId = hre.ethers.utils.keccak256(
+      hre.ethers.utils.solidityPack(['address', 'bytes32'], [airnodeAddress, templateId])
+    );
+    await dapiServer.connect(roles.manager).setDapiName(dapiName, beaconId);
+    beaconValue = 123;
+    beaconTimestamp = await testUtils.getCurrentTimestamp(hre.ethers.provider);
+    const data = hre.ethers.utils.defaultAbiCoder.encode(['int256'], [beaconValue]);
+    const signature = await airnodeWallet.signMessage(
+      hre.ethers.utils.arrayify(
+        hre.ethers.utils.keccak256(
+          hre.ethers.utils.solidityPack(['bytes32', 'uint256', 'bytes'], [templateId, beaconTimestamp, data])
+        )
+      )
+    );
+    await hre.ethers.provider.send('evm_setNextBlockTimestamp', [beaconTimestamp + 1]);
+    await dapiServer.updateBeaconWithSignedData(airnodeAddress, templateId, beaconTimestamp, data, signature);
+
+    const proxyFactoryFactory = await hre.ethers.getContractFactory('ProxyFactory', roles.deployer);
+    proxyFactory = await proxyFactoryFactory.deploy(dapiServer.address);
+  });
+
+  describe('deploy', function () {
+    it('deploys', async function () {
+      // Precompute the proxy address
+      const DataFeedProxy = await hre.artifacts.readArtifact('DataFeedProxy');
+      const initcode = hre.ethers.utils.solidityPack(
+        ['bytes', 'bytes'],
+        [
+          DataFeedProxy.bytecode,
+          hre.ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [dapiServer.address, beaconId]),
+        ]
+      );
+      const proxyAddress = hre.ethers.utils.getCreate2Address(
+        proxyFactory.address,
+        hre.ethers.constants.HashZero,
+        hre.ethers.utils.keccak256(initcode)
+      );
+
+      // metadata includes information like policy hash, commission recipient, etc.
+      const metadata = testUtils.generateRandomBytes();
+      // Can only deploy once
+      await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata))
+        .to.emit(proxyFactory, 'DeployedDataFeedProxy')
+        .withArgs(proxyAddress, beaconId, metadata);
+      // Subsequent deployments will revert
+      await expect(proxyFactory.deployDataFeedProxy(beaconId, metadata)).to.be.revertedWith('Proxy already deployed');
+
+      // Confirm that the bytecode is the same
+      const dataFeedProxyFactory = await hre.ethers.getContractFactory('DataFeedProxy', roles.deployer);
+      const eoaDeployedDataFeedProxy = await dataFeedProxyFactory.deploy(dapiServer.address, beaconId);
+      expect(await hre.ethers.provider.getCode(proxyAddress)).to.equal(
+        await hre.ethers.provider.getCode(eoaDeployedDataFeedProxy.address)
+      );
+
+      // Test the deployed contract
+      const dataFeedProxy = new hre.ethers.Contract(proxyAddress, DataFeedProxy.abi, hre.ethers.provider);
+      expect(await dataFeedProxy.dapiServer()).to.equal(dapiServer.address);
+      expect(await dataFeedProxy.dataFeedId()).to.equal(beaconId);
+      const beacon = await dataFeedProxy.read();
+      expect(beacon.value).to.equal(beaconValue);
+      expect(beacon.timestamp).to.equal(beaconTimestamp);
+    });
+  });
+});


### PR DESCRIPTION
Closes #58 https://github.com/api3dao/airnode-protocol-v1/issues/65

I started off by implementing what I was talking about earlier, i.e., a factory that can be configured to allow/disallow the deployment of arbitrary contracts. That requires the deployment transaction to provide the entire bytecode in calldata, which costs an additional 20,000 (so 200,000 -> 220,000 gas cost for a DapiProxy deployment, more for the OEV counterparts). I figured that being able to register new proxy contract types isn't worth this overhead, especially since we don't foresee using that feature. So I embedded the four proxy types in the factory contract instead, which results in the cheapest deployment (along with https://github.com/api3dao/airnode-protocol-v1/issues/66).

Note that I also walked back on having people deploy proxies if an identical proxy is already deployed. I think we should discuss how this should be handled again (@RiVal-cz for visibility). It's easy to revert back to the "always deploy a new proxy" scheme, we just replace the Assembly parts with `new`.