### PR TITLE
Add meta-tx nullification

### DIFF
--- a/contracts/utils/interfaces/IExpiringMetaTxForwarder.sol
+++ b/contracts/utils/interfaces/IExpiringMetaTxForwarder.sol
@@ -2,6 +2,10 @@
 pragma solidity ^0.8.0;
 
 interface IExpiringMetaTxForwarder {
+    event ExecutedMetaTx(bytes32 indexed metaTxHash);
+
+    event NullifiedMetaTx(bytes32 indexed metaTxHash);
+
     struct ExpiringMetaTx {
         address from;
         address to;
@@ -14,7 +18,9 @@ interface IExpiringMetaTxForwarder {
         bytes calldata signature
     ) external returns (bytes memory returndata);
 
-    function metaTxWithHashIsExecuted(
+    function nullify(ExpiringMetaTx calldata metaTx) external;
+
+    function metaTxWithHashIsExecutedOrNullified(
         bytes32 metaTxHash
     ) external returns (bool);
 }

--- a/contracts/utils/interfaces/IExpiringMetaTxForwarder.sol
+++ b/contracts/utils/interfaces/IExpiringMetaTxForwarder.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 interface IExpiringMetaTxForwarder {
     event ExecutedMetaTx(bytes32 indexed metaTxHash);
 
-    event NullifiedMetaTx(bytes32 indexed metaTxHash);
+    event CanceledMetaTx(bytes32 indexed metaTxHash);
 
     struct ExpiringMetaTx {
         address from;
@@ -18,9 +18,9 @@ interface IExpiringMetaTxForwarder {
         bytes calldata signature
     ) external returns (bytes memory returndata);
 
-    function nullify(ExpiringMetaTx calldata metaTx) external;
+    function cancel(ExpiringMetaTx calldata metaTx) external;
 
-    function metaTxWithHashIsExecutedOrNullified(
+    function metaTxWithHashIsExecutedOrCanceled(
         bytes32 metaTxHash
     ) external returns (bool);
 }

--- a/test/utils/ExpiringMetaTxForwarder.sol.js
+++ b/test/utils/ExpiringMetaTxForwarder.sol.js
@@ -73,52 +73,73 @@ describe('ExpiringMetaTxForwarder', function () {
 
   describe('execute', function () {
     context('Meta-tx with hash is not executed', function () {
-      context('Meta-tx has not expired', function () {
-        context('Signature is valid', function () {
-          it('executes', async function () {
-            const {
-              roles,
-              expiringMetaTxForwarder,
-              expiringMetaTxForwarderTarget,
-              expiringMetaTxDomain,
-              expiringMetaTxTypes,
-              expiringMetaTxValue,
-            } = await helpers.loadFixture(deploy);
+      context('Meta-tx with hash is not nullified', function () {
+        context('Meta-tx has not expired', function () {
+          context('Signature is valid', function () {
+            it('executes', async function () {
+              const {
+                roles,
+                expiringMetaTxForwarder,
+                expiringMetaTxForwarderTarget,
+                expiringMetaTxDomain,
+                expiringMetaTxTypes,
+                expiringMetaTxValue,
+              } = await helpers.loadFixture(deploy);
+              const signature = await roles.owner._signTypedData(
+                expiringMetaTxDomain,
+                expiringMetaTxTypes,
+                expiringMetaTxValue
+              );
+              const counterInitial = await expiringMetaTxForwarderTarget.counter();
+              const metaTxTypedDataHash = deriveTypedDataHashOfMetaTx(expiringMetaTxDomain, expiringMetaTxValue);
+              expect(await expiringMetaTxForwarder.metaTxWithHashIsExecutedOrNullified(metaTxTypedDataHash)).to.equal(
+                false
+              );
+              const returndata = await expiringMetaTxForwarder
+                .connect(roles.randomPerson)
+                .callStatic.execute(expiringMetaTxValue, signature);
+              expect(returndata).to.equal(counterInitial.add(1));
+              await expect(expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature))
+                .to.emit(expiringMetaTxForwarder, 'ExecutedMetaTx')
+                .withArgs(metaTxTypedDataHash);
+              expect(await expiringMetaTxForwarderTarget.counter()).to.be.equal(counterInitial.add(1));
+              expect(await expiringMetaTxForwarder.metaTxWithHashIsExecutedOrNullified(metaTxTypedDataHash)).to.equal(
+                true
+              );
+            });
+          });
+          context('Signature is not valid', function () {
+            it('reverts', async function () {
+              const { roles, expiringMetaTxForwarder, expiringMetaTxDomain, expiringMetaTxTypes, expiringMetaTxValue } =
+                await helpers.loadFixture(deploy);
+              const signature = await roles.randomPerson._signTypedData(
+                expiringMetaTxDomain,
+                expiringMetaTxTypes,
+                expiringMetaTxValue
+              );
+              await expect(
+                expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature)
+              ).to.be.revertedWith('Invalid signature');
+            });
+          });
+        });
+        context('Meta-tx has expired', function () {
+          it('reverts', async function () {
+            const { roles, expiringMetaTxForwarder, expiringMetaTxDomain, expiringMetaTxTypes, expiringMetaTxValue } =
+              await helpers.loadFixture(deploy);
             const signature = await roles.owner._signTypedData(
               expiringMetaTxDomain,
               expiringMetaTxTypes,
               expiringMetaTxValue
             );
-            const counterInitial = await expiringMetaTxForwarderTarget.counter();
-            const metaTxTypedDataHash = deriveTypedDataHashOfMetaTx(expiringMetaTxDomain, expiringMetaTxValue);
-            expect(await expiringMetaTxForwarder.metaTxWithHashIsExecuted(metaTxTypedDataHash)).to.equal(false);
-            const returndata = await expiringMetaTxForwarder
-              .connect(roles.randomPerson)
-              .callStatic.execute(expiringMetaTxValue, signature);
-            expect(returndata).to.equal(counterInitial.add(1));
+            await helpers.time.setNextBlockTimestamp(expiringMetaTxValue.expirationTimestamp);
             await expect(
               expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature)
-            ).to.not.be.reverted;
-            expect(await expiringMetaTxForwarderTarget.counter()).to.be.equal(counterInitial.add(1));
-            expect(await expiringMetaTxForwarder.metaTxWithHashIsExecuted(metaTxTypedDataHash)).to.equal(true);
-          });
-        });
-        context('Signature is not valid', function () {
-          it('reverts', async function () {
-            const { roles, expiringMetaTxForwarder, expiringMetaTxDomain, expiringMetaTxTypes, expiringMetaTxValue } =
-              await helpers.loadFixture(deploy);
-            const signature = await roles.randomPerson._signTypedData(
-              expiringMetaTxDomain,
-              expiringMetaTxTypes,
-              expiringMetaTxValue
-            );
-            await expect(
-              expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature)
-            ).to.be.revertedWith('Invalid signature');
+            ).to.be.revertedWith('Meta-tx expired');
           });
         });
       });
-      context('Meta-tx has expired', function () {
+      context('Meta-tx with hash is nullified', function () {
         it('reverts', async function () {
           const { roles, expiringMetaTxForwarder, expiringMetaTxDomain, expiringMetaTxTypes, expiringMetaTxValue } =
             await helpers.loadFixture(deploy);
@@ -127,10 +148,10 @@ describe('ExpiringMetaTxForwarder', function () {
             expiringMetaTxTypes,
             expiringMetaTxValue
           );
-          await helpers.time.setNextBlockTimestamp(expiringMetaTxValue.expirationTimestamp);
+          await expiringMetaTxForwarder.connect(roles.owner).nullify(expiringMetaTxValue);
           await expect(
             expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature)
-          ).to.be.revertedWith('Meta-tx expired');
+          ).to.be.revertedWith('Meta-tx executed or nullified');
         });
       });
     });
@@ -146,7 +167,80 @@ describe('ExpiringMetaTxForwarder', function () {
         await expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature);
         await expect(
           expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature)
-        ).to.be.revertedWith('Meta-tx already executed');
+        ).to.be.revertedWith('Meta-tx executed or nullified');
+      });
+    });
+  });
+
+  describe('nullify', function () {
+    context('Sender is meta-tx source', function () {
+      context('Meta-tx with hash is not executed yet', function () {
+        context('Meta-tx with hash is not nullified yet', function () {
+          context('Meta-tx has not expired', function () {
+            it('nullifies', async function () {
+              const {
+                roles,
+                expiringMetaTxForwarder,
+                expiringMetaTxForwarderTarget,
+                expiringMetaTxDomain,
+                expiringMetaTxValue,
+              } = await helpers.loadFixture(deploy);
+              const counterInitial = await expiringMetaTxForwarderTarget.counter();
+              const metaTxTypedDataHash = deriveTypedDataHashOfMetaTx(expiringMetaTxDomain, expiringMetaTxValue);
+              expect(await expiringMetaTxForwarder.metaTxWithHashIsExecutedOrNullified(metaTxTypedDataHash)).to.equal(
+                false
+              );
+              await expect(expiringMetaTxForwarder.connect(roles.owner).nullify(expiringMetaTxValue))
+                .to.emit(expiringMetaTxForwarder, 'NullifiedMetaTx')
+                .withArgs(metaTxTypedDataHash);
+              expect(await expiringMetaTxForwarderTarget.counter()).to.be.equal(counterInitial);
+              expect(await expiringMetaTxForwarder.metaTxWithHashIsExecutedOrNullified(metaTxTypedDataHash)).to.equal(
+                true
+              );
+            });
+          });
+          context('Meta-tx has expired', function () {
+            it('reverts', async function () {
+              const { roles, expiringMetaTxForwarder, expiringMetaTxValue } = await helpers.loadFixture(deploy);
+              await helpers.time.setNextBlockTimestamp(expiringMetaTxValue.expirationTimestamp);
+              await expect(
+                expiringMetaTxForwarder.connect(roles.owner).nullify(expiringMetaTxValue)
+              ).to.be.revertedWith('Meta-tx expired');
+            });
+          });
+        });
+        context('Meta-tx with hash is already nullified', function () {
+          it('reverts', async function () {
+            const { roles, expiringMetaTxForwarder, expiringMetaTxValue } = await helpers.loadFixture(deploy);
+            await expiringMetaTxForwarder.connect(roles.owner).nullify(expiringMetaTxValue);
+            await expect(expiringMetaTxForwarder.connect(roles.owner).nullify(expiringMetaTxValue)).to.be.revertedWith(
+              'Meta-tx executed or nullified'
+            );
+          });
+        });
+      });
+      context('Meta-tx with hash is already executed', function () {
+        it('reverts', async function () {
+          const { roles, expiringMetaTxForwarder, expiringMetaTxDomain, expiringMetaTxTypes, expiringMetaTxValue } =
+            await helpers.loadFixture(deploy);
+          const signature = await roles.owner._signTypedData(
+            expiringMetaTxDomain,
+            expiringMetaTxTypes,
+            expiringMetaTxValue
+          );
+          await expiringMetaTxForwarder.connect(roles.randomPerson).execute(expiringMetaTxValue, signature);
+          await expect(expiringMetaTxForwarder.connect(roles.owner).nullify(expiringMetaTxValue)).to.be.revertedWith(
+            'Meta-tx executed or nullified'
+          );
+        });
+      });
+    });
+    context('Sender is not meta-tx source', function () {
+      it('reverts', async function () {
+        const { roles, expiringMetaTxForwarder, expiringMetaTxValue } = await helpers.loadFixture(deploy);
+        await expect(
+          expiringMetaTxForwarder.connect(roles.randomPerson).nullify(expiringMetaTxValue)
+        ).to.be.revertedWith('Sender not meta-tx source');
       });
     });
   });


### PR DESCRIPTION
I figured it's a good idea to be able to nullify previously issued signatures. The nullification can also be done through meta-txes if the inheriting contract supports it (which AccessControlRegistry does).