### PR TITLE
Don't store description hashes for contracts with managers

### DIFF
--- a/contracts/allocators/Allocator.sol
+++ b/contracts/allocators/Allocator.sol
@@ -26,9 +26,6 @@ abstract contract Allocator is IAllocator {
         public
         override airnodeToSlotIndexToSlot;
 
-    bytes32 internal constant SLOT_SETTER_ROLE_DESCRIPTION_HASH =
-        keccak256(abi.encodePacked(SLOT_SETTER_ROLE_DESCRIPTION));
-
     /// @notice Resets the slot
     /// @dev This will revert if the slot has been set before, and the sender
     /// is not the setter of the slot, and the slot has not expired and the

--- a/contracts/allocators/AllocatorWithAirnode.sol
+++ b/contracts/allocators/AllocatorWithAirnode.sol
@@ -14,6 +14,9 @@ contract AllocatorWithAirnode is
     Allocator,
     IAllocatorWithAirnode
 {
+    bytes32 private constant SLOT_SETTER_ROLE_DESCRIPTION_HASH =
+        keccak256(abi.encodePacked(SLOT_SETTER_ROLE_DESCRIPTION));
+
     /// @param _accessControlRegistry AccessControlRegistry contract address
     /// @param _adminRoleDescription Admin role description
     constructor(

--- a/contracts/allocators/AllocatorWithManager.sol
+++ b/contracts/allocators/AllocatorWithManager.sol
@@ -34,7 +34,7 @@ contract AllocatorWithManager is
     {
         slotSetterRole = _deriveRole(
             adminRole,
-            SLOT_SETTER_ROLE_DESCRIPTION_HASH
+            keccak256(abi.encodePacked(SLOT_SETTER_ROLE_DESCRIPTION))
         );
     }
 

--- a/contracts/authorizers/RequesterAuthorizer.sol
+++ b/contracts/authorizers/RequesterAuthorizer.sol
@@ -31,21 +31,6 @@ abstract contract RequesterAuthorizer is IRequesterAuthorizer {
     string public constant override INDEFINITE_AUTHORIZER_ROLE_DESCRIPTION =
         "Indefinite authorizer";
 
-    bytes32
-        internal constant AUTHORIZATION_EXPIRATION_EXTENDER_ROLE_DESCRIPTION_HASH =
-        keccak256(
-            abi.encodePacked(AUTHORIZATION_EXPIRATION_EXTENDER_ROLE_DESCRIPTION)
-        );
-
-    bytes32
-        internal constant AUTHORIZATION_EXPIRATION_SETTER_ROLE_DESCRIPTION_HASH =
-        keccak256(
-            abi.encodePacked(AUTHORIZATION_EXPIRATION_SETTER_ROLE_DESCRIPTION)
-        );
-
-    bytes32 internal constant INDEFINITE_AUTHORIZER_ROLE_DESCRIPTION_HASH =
-        keccak256(abi.encodePacked(INDEFINITE_AUTHORIZER_ROLE_DESCRIPTION));
-
     mapping(address => mapping(address => AuthorizationStatus))
         public
         override airnodeToRequesterToAuthorizationStatus;

--- a/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithAirnode.sol
@@ -14,6 +14,21 @@ contract RequesterAuthorizerWithAirnode is
     RequesterAuthorizer,
     IRequesterAuthorizerWithAirnode
 {
+    bytes32
+        private constant AUTHORIZATION_EXPIRATION_EXTENDER_ROLE_DESCRIPTION_HASH =
+        keccak256(
+            abi.encodePacked(AUTHORIZATION_EXPIRATION_EXTENDER_ROLE_DESCRIPTION)
+        );
+
+    bytes32
+        private constant AUTHORIZATION_EXPIRATION_SETTER_ROLE_DESCRIPTION_HASH =
+        keccak256(
+            abi.encodePacked(AUTHORIZATION_EXPIRATION_SETTER_ROLE_DESCRIPTION)
+        );
+
+    bytes32 private constant INDEFINITE_AUTHORIZER_ROLE_DESCRIPTION_HASH =
+        keccak256(abi.encodePacked(INDEFINITE_AUTHORIZER_ROLE_DESCRIPTION));
+
     /// @param _accessControlRegistry AccessControlRegistry contract address
     /// @param _adminRoleDescription Admin role description
     constructor(

--- a/contracts/authorizers/RequesterAuthorizerWithManager.sol
+++ b/contracts/authorizers/RequesterAuthorizerWithManager.sol
@@ -40,15 +40,23 @@ contract RequesterAuthorizerWithManager is
     {
         authorizationExpirationExtenderRole = _deriveRole(
             adminRole,
-            AUTHORIZATION_EXPIRATION_EXTENDER_ROLE_DESCRIPTION_HASH
+            keccak256(
+                abi.encodePacked(
+                    AUTHORIZATION_EXPIRATION_EXTENDER_ROLE_DESCRIPTION
+                )
+            )
         );
         authorizationExpirationSetterRole = _deriveRole(
             adminRole,
-            AUTHORIZATION_EXPIRATION_SETTER_ROLE_DESCRIPTION_HASH
+            keccak256(
+                abi.encodePacked(
+                    AUTHORIZATION_EXPIRATION_SETTER_ROLE_DESCRIPTION
+                )
+            )
         );
         indefiniteAuthorizerRole = _deriveRole(
             adminRole,
-            INDEFINITE_AUTHORIZER_ROLE_DESCRIPTION_HASH
+            keccak256(abi.encodePacked(INDEFINITE_AUTHORIZER_ROLE_DESCRIPTION))
         );
     }
 


### PR DESCRIPTION
I investigated https://github.com/api3dao/airnode-protocol-v1/issues/83 again only found this to be an improvement with no drawbacks. The contracts with managers were storing the role description hashes only to be used once in the constructor.