### PR TITLE
Median Beacon set timestamp

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -891,17 +891,17 @@ contract DapiServer is
         uint256 beaconCount = beaconIds.length;
         require(beaconCount > 1, "Specified less than two Beacons");
         int256[] memory values = new int256[](beaconCount);
-        uint256 accumulatedTimestamp = 0;
+        int256[] memory timestamps = new int256[](beaconCount);
         for (uint256 ind = 0; ind < beaconCount; ) {
             DataFeed storage dataFeed = dataFeeds[beaconIds[ind]];
             values[ind] = dataFeed.value;
+            timestamps[ind] = int256(uint256(dataFeed.timestamp));
             unchecked {
-                accumulatedTimestamp += dataFeed.timestamp;
                 ind++;
             }
         }
         value = int224(median(values));
-        timestamp = uint32(accumulatedTimestamp / beaconCount);
+        timestamp = uint32(uint256(median(timestamps)));
     }
 
     /// @notice Derives the Beacon ID from the Airnode address and template ID

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -507,10 +507,13 @@ contract DapiServer is
             beaconIds
         );
         beaconSetId = deriveBeaconSetId(beaconIds);
-        require(
-            updatedTimestamp > dataFeeds[beaconSetId].timestamp,
-            "Does not update timestamp"
-        );
+        DataFeed storage beaconSet = dataFeeds[beaconSetId];
+        if (beaconSet.timestamp == updatedTimestamp) {
+            require(
+                beaconSet.value != updatedValue,
+                "Does not update Beacon set"
+            );
+        }
         dataFeeds[beaconSetId] = DataFeed({
             value: updatedValue,
             timestamp: updatedTimestamp

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -329,13 +329,13 @@ contract DapiServer is
     ) external override onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         bytes32 beaconId = requestIdToBeaconId[requestId];
         delete requestIdToBeaconId[requestId];
-        int224 decodedData = processBeaconUpdate(beaconId, timestamp, data);
+        int224 updatedValue = processBeaconUpdate(beaconId, timestamp, data);
         // Timestamp validity is already checked by `onlyValidTimestamp`, which
         // means it will be small enough to be typecast into `uint32`
         emit UpdatedBeaconWithRrp(
             beaconId,
             requestId,
-            decodedData,
+            updatedValue,
             uint32(timestamp)
         );
     }
@@ -481,13 +481,13 @@ contract DapiServer is
         bytes32 beaconId = subscriptionIdToBeaconId[subscriptionId];
         // Beacon ID is guaranteed to not be zero because the subscription is
         // registered
-        int224 decodedData = processBeaconUpdate(beaconId, timestamp, data);
+        int224 updatedValue = processBeaconUpdate(beaconId, timestamp, data);
         // Timestamp validity is already checked by `onlyValidTimestamp`, which
         // means it will be small enough to be typecast into `uint32`
         emit UpdatedBeaconWithPsp(
             beaconId,
             subscriptionId,
-            decodedData,
+            updatedValue,
             uint32(timestamp)
         );
     }

--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -11,14 +11,15 @@ import "./interfaces/IDapiProxy.sol";
 /// a signed integer, yet it being negative may not make sense in the case that
 /// the data feed represents the spot price of an asset. In that case, the user
 /// is responsible with ensuring that `value` is not negative.
-/// `timestamp` is derived from the system times of the Airnodes that signed
-/// the data that contributed to the most recent update (which is not equal to
-/// the block time of the most recent update). Its main function is to prevent
-/// out of date values from being used to update data feeds. If you will be
-/// implementing a contract that uses `timestamp` in the contract logic in any
-/// way (e.g., reject readings with `timestamp` that is more than 1 day old),
-/// make sure to refer to DapiServer.sol and understand how this number is
-/// derived.
+/// In the case that the data feed is from a single source, `timestamp` is the
+/// system time of the Airnode when it signed the data. In the case that the
+/// data feed is from multiple sources, `timestamp` is the median of system
+/// times of the respective Airnodes when they signed the data. There are two
+/// points to consider while using `timestamp` in your contract logic: (1) It
+/// is based on the system time of the Airnodes, and not the block timestamp.
+/// This may be relevant when either of them drifts. (2) `timestamp` is an
+/// off-chain value that is being reported, similar to `value`. Both should
+/// only be trusted as much as the Airnode(s) that report them.
 contract DapiProxy is IDapiProxy {
     /// @notice DapiServer address
     address public immutable override dapiServer;

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -2867,8 +2867,8 @@ describe('DapiServer', function () {
   });
 
   describe('updateBeaconWithSignedData', function () {
-    context('Signature is valid', function () {
-      context('Timestamp is valid', function () {
+    context('Timestamp is valid', function () {
+      context('Signature is valid', function () {
         context('Fulfillment data length is correct', function () {
           context('Decoded fulfillment data can be typecasted into int224', function () {
             context('Updates timestamp', function () {
@@ -3009,69 +3009,69 @@ describe('DapiServer', function () {
           });
         });
       });
-      context('Timestamp is not valid', function () {
+      context('Signature is not valid', function () {
         it('reverts', async function () {
           const { roles, dapiServer, beacons } = await deploy();
           const beacon = beacons[0];
           const beaconValue = Math.floor(Math.random() * 200 - 100);
-          const nextTimestamp = (await helpers.time.latest()) + 1;
-          await helpers.time.setNextBlockTimestamp(nextTimestamp);
-          const beaconTimestampTooLate = nextTimestamp - 60 * 60;
-          const signatureTooLate = await testUtils.signData(
-            beacon.airnode.wallet,
-            beacon.templateId,
-            beaconTimestampTooLate,
-            encodeData(beaconValue)
-          );
+          const beaconTimestamp = await helpers.time.latest();
           await expect(
             dapiServer
               .connect(roles.randomPerson)
               .updateBeaconWithSignedData(
                 beacon.airnode.wallet.address,
                 beacon.templateId,
-                beaconTimestampTooLate,
+                beaconTimestamp,
                 encodeData(beaconValue),
-                signatureTooLate
+                '0x12345678'
               )
-          ).to.be.revertedWith('Timestamp not valid');
-          const beaconTimestampFromFuture = nextTimestamp + 15 * 60 + 1;
-          const signatureFromFuture = await testUtils.signData(
-            beacon.airnode.wallet,
-            beacon.templateId,
-            beaconTimestampFromFuture,
-            encodeData(beaconValue)
-          );
-          await expect(
-            dapiServer
-              .connect(roles.randomPerson)
-              .updateBeaconWithSignedData(
-                beacon.airnode.wallet.address,
-                beacon.templateId,
-                beaconTimestampFromFuture,
-                encodeData(beaconValue),
-                signatureFromFuture
-              )
-          ).to.be.revertedWith('Timestamp not valid');
+          ).to.be.revertedWith('ECDSA: invalid signature length');
         });
       });
     });
-    context('Signature is not valid', function () {
+    context('Timestamp is not valid', function () {
       it('reverts', async function () {
         const { roles, dapiServer, beacons } = await deploy();
         const beacon = beacons[0];
         const beaconValue = Math.floor(Math.random() * 200 - 100);
-        const beaconTimestamp = await helpers.time.latest();
+        const nextTimestamp = (await helpers.time.latest()) + 1;
+        await helpers.time.setNextBlockTimestamp(nextTimestamp);
+        const beaconTimestampTooLate = nextTimestamp - 60 * 60;
+        const signatureTooLate = await testUtils.signData(
+          beacon.airnode.wallet,
+          beacon.templateId,
+          beaconTimestampTooLate,
+          encodeData(beaconValue)
+        );
         await expect(
           dapiServer
             .connect(roles.randomPerson)
             .updateBeaconWithSignedData(
               beacon.airnode.wallet.address,
               beacon.templateId,
-              beaconTimestamp,
+              beaconTimestampTooLate,
               encodeData(beaconValue),
-              '0x12345678'
+              signatureTooLate
             )
-        ).to.be.revertedWith('ECDSA: invalid signature length');
+        ).to.be.revertedWith('Timestamp not valid');
+        const beaconTimestampFromFuture = nextTimestamp + 15 * 60 + 1;
+        const signatureFromFuture = await testUtils.signData(
+          beacon.airnode.wallet,
+          beacon.templateId,
+          beaconTimestampFromFuture,
+          encodeData(beaconValue)
+        );
+        await expect(
+          dapiServer
+            .connect(roles.randomPerson)
+            .updateBeaconWithSignedData(
+              beacon.airnode.wallet.address,
+              beacon.templateId,
+              beaconTimestampFromFuture,
+              encodeData(beaconValue),
+              signatureFromFuture
+            )
+        ).to.be.revertedWith('Timestamp not valid');
       });
     });
   });

--- a/test/dapis/DapiServer.sol.js
+++ b/test/dapis/DapiServer.sol.js
@@ -2399,11 +2399,7 @@ describe('DapiServer', function () {
             })
           );
           const beaconSetValue = median(beaconValues);
-          const beaconSetTimestamp = Math.floor(
-            beaconTimestamps.reduce((sum, beaconTimestamp) => {
-              return sum + beaconTimestamp;
-            }, 0) / beaconTimestamps.length
-          );
+          const beaconSetTimestamp = median(beaconTimestamps);
           const beaconSetBefore = await dapiServer.dataFeeds(beaconSet.beaconSetId);
           expect(beaconSetBefore.value).to.equal(0);
           expect(beaconSetBefore.timestamp).to.equal(0);
@@ -2739,11 +2735,7 @@ describe('DapiServer', function () {
             })
           );
           const beaconSetValue = median(beaconValues);
-          const beaconSetTimestamp = Math.floor(
-            beaconTimestamps.reduce((sum, beaconTimestamp) => {
-              return sum + beaconTimestamp;
-            }, 0) / beaconTimestamps.length
-          );
+          const beaconSetTimestamp = median(beaconTimestamps);
           const data = ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [beaconSet.beaconIds]);
           const timestamp = await helpers.time.latest();
           const signature = testUtils.signPspFulfillment(
@@ -2791,11 +2783,7 @@ describe('DapiServer', function () {
             })
           );
           const beaconSetValue = median(beaconValues);
-          const beaconSetTimestamp = Math.floor(
-            beaconTimestamps.reduce((sum, beaconTimestamp) => {
-              return sum + beaconTimestamp;
-            }, 0) / beaconTimestamps.length
-          );
+          const beaconSetTimestamp = median(beaconTimestamps);
           const beaconSetUpdateSubscriptionId = await deriveUpdateSubscriptionId(
             dapiServer,
             beacons[0].airnode.wallet.address,


### PR DESCRIPTION
Addressing API3-02

- Uses median instead of mean to calculate Beacon set timestamps
- Allows `updateBeaconSetWithBeacons()` even if it doesn't update the Beacon set timestamp, as long as it updates the Beacon set value. This is because updating individual Beacons will not necessarily affect the Beacon set timestamp, but the resulting value will be fresher
- Small `updateBeaconWithSignedData()` refactor