### PR TITLE
Remove aggregation interface

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -876,32 +876,6 @@ contract DapiServer is
         require(timestamp > 0, "Data feed not initialized");
     }
 
-    /// @notice Called privately to aggregate the Beacons and return the result
-    /// @dev Tha aggregation of Beacons may have a different value than the
-    /// respective Beacon set, e.g., because the Beacon set has been updated
-    /// using signed data
-    /// @param beaconIds Beacon IDs
-    /// @return value Aggregation value
-    /// @return timestamp Aggregation timestamp
-    function aggregateBeacons(
-        bytes32[] memory beaconIds
-    ) private view returns (int224 value, uint32 timestamp) {
-        uint256 beaconCount = beaconIds.length;
-        require(beaconCount > 1, "Specified less than two Beacons");
-        int256[] memory values = new int256[](beaconCount);
-        int256[] memory timestamps = new int256[](beaconCount);
-        for (uint256 ind = 0; ind < beaconCount; ) {
-            DataFeed storage dataFeed = dataFeeds[beaconIds[ind]];
-            values[ind] = dataFeed.value;
-            timestamps[ind] = int256(uint256(dataFeed.timestamp));
-            unchecked {
-                ind++;
-            }
-        }
-        value = int224(median(values));
-        timestamp = uint32(uint256(median(timestamps)));
-    }
-
     /// @notice Derives the Beacon ID from the Airnode address and template ID
     /// @param airnode Airnode address
     /// @param templateId Template ID
@@ -994,6 +968,32 @@ contract DapiServer is
                 (heartbeatInterval != 0 &&
                     dataFeed.timestamp + heartbeatInterval <= updatedTimestamp);
         }
+    }
+
+    /// @notice Called privately to aggregate the Beacons and return the result
+    /// @dev Tha aggregation of Beacons may have a different value than the
+    /// respective Beacon set, e.g., because the Beacon set has been updated
+    /// using signed data
+    /// @param beaconIds Beacon IDs
+    /// @return value Aggregation value
+    /// @return timestamp Aggregation timestamp
+    function aggregateBeacons(
+        bytes32[] memory beaconIds
+    ) private view returns (int224 value, uint32 timestamp) {
+        uint256 beaconCount = beaconIds.length;
+        require(beaconCount > 1, "Specified less than two Beacons");
+        int256[] memory values = new int256[](beaconCount);
+        int256[] memory timestamps = new int256[](beaconCount);
+        for (uint256 ind = 0; ind < beaconCount; ) {
+            DataFeed storage dataFeed = dataFeeds[beaconIds[ind]];
+            values[ind] = dataFeed.value;
+            timestamps[ind] = int256(uint256(dataFeed.timestamp));
+            unchecked {
+                ind++;
+            }
+        }
+        value = int224(median(values));
+        timestamp = uint32(uint256(median(timestamps)));
     }
 
     /// @notice Called privately to calculate the update magnitude in

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -876,7 +876,7 @@ contract DapiServer is
         require(timestamp > 0, "Data feed not initialized");
     }
 
-    /// @notice Aggregates the Beacons and returns the result
+    /// @notice Called privately to aggregate the Beacons and return the result
     /// @dev Tha aggregation of Beacons may have a different value than the
     /// respective Beacon set, e.g., because the Beacon set has been updated
     /// using signed data
@@ -885,7 +885,7 @@ contract DapiServer is
     /// @return timestamp Aggregation timestamp
     function aggregateBeacons(
         bytes32[] memory beaconIds
-    ) public view override returns (int224 value, uint32 timestamp) {
+    ) private view returns (int224 value, uint32 timestamp) {
         uint256 beaconCount = beaconIds.length;
         require(beaconCount > 1, "Specified less than two Beacons");
         int256[] memory values = new int256[](beaconCount);

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -216,10 +216,6 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
         bytes32 dapiNameHash
     ) external view returns (int224 value, uint32 timestamp);
 
-    function aggregateBeacons(
-        bytes32[] memory beaconIds
-    ) external view returns (int224 value, uint32 timestamp);
-
     // solhint-disable-next-line func-name-mixedcase
     function DAPI_NAME_SETTER_ROLE_DESCRIPTION()
         external


### PR DESCRIPTION
Addresses API3-02

Makes `aggregateBeacons()` private. As a note, the response plan mentioned having `updateBeaconSetWithBeacons()` return the updated Beacon set to replace the `aggregateBeacons()` interface in function. However, this doesn't really work because `updateBeaconSetWithBeacons()` reverts if it can't update the Beacon set. The reader forcing Beacon set updates beforehand is not the intended user flow so I decided against reworking the interface just to enable this. This is still possible in a few ways:
- The reader `tryMulticall()`s a `updateBeaconSetWithBeacons()` and the read call
- The reader calls `updateBeaconSetWithBeacons()` in a try-catch statement
- The reader makes a low-level call to `updateBeaconSetWithBeacons()` and doesn't care if the call fails