### PR TITLE
Do not invalidate old signatures

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -1080,8 +1080,22 @@ contract DapiServer is
                 "Signature mismatch"
             );
             beaconValue = decodeFulfillmentData(data);
-            require(timestampIsValid(timestamp), "Timestamp not valid");
+            require(
+                timestamp != 0 && timestampIsValid(timestamp),
+                "Timestamp not valid"
+            );
             beaconTimestamp = uint32(timestamp);
         }
+    }
+
+    /// @notice Overriden to prevent a Beacon from being updated by an
+    /// unreasonably large timestamp, which would block all following updates
+    /// @dev The timestamp is allowed to be up to 1 hour later than
+    /// `block.timestamp` to tolerate chain clock drift
+    /// @param timestamp Timestamp used in the signature
+    function timestampIsValid(
+        uint256 timestamp
+    ) internal view virtual override returns (bool) {
+        return timestamp < block.timestamp + 1 hours;
     }
 }

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -1096,6 +1096,8 @@ contract DapiServer is
     function timestampIsValid(
         uint256 timestamp
     ) internal view virtual override returns (bool) {
-        return timestamp < block.timestamp + 1 hours;
+        unchecked {
+            return timestamp < block.timestamp + 1 hours;
+        }
     }
 }

--- a/contracts/protocol/AirnodeRequester.sol
+++ b/contracts/protocol/AirnodeRequester.sol
@@ -6,7 +6,7 @@ import "./interfaces/IAirnodeRequester.sol";
 
 /// @title Contract to be inherited by contracts that will make Airnode
 /// requests and receive fulfillments
-contract AirnodeRequester is IAirnodeRequester {
+abstract contract AirnodeRequester is IAirnodeRequester {
     /// @notice AirnodeProtocol contract address
     address public immutable override airnodeProtocol;
 
@@ -34,22 +34,20 @@ contract AirnodeRequester is IAirnodeRequester {
         airnodeProtocol = _airnodeProtocol;
     }
 
-    /// @notice Returns if the timestamp used in the signature is valid
+    /// @notice Overriden by the inheriting contract to return if the timestamp
+    /// used in the signature is valid
     /// @dev If and how the timestamp should be validated depends on the nature
     /// of the request. If the request is "return me the price of this asset at
     /// this specific time in history", it can be assumed that the response
     /// will not go out of date. If the request is "return me the price of this
     /// asset now", the requester would rather not consider a response that is
-    /// not immediate. Since users commonly make the latter type of requests,
-    /// we provide an example timestamp validation function. Feel free to use a
-    /// different condition or even omit it if you are aware of the
-    /// implications.
+    /// not immediate.
+    /// In addition to the nature of the request, if and how the timestamp is
+    /// used in the contract logic determines how it should be validated.
+    /// In general, one should keep in mind that similar to the fulfillment
+    /// data, it is possible for the timestamp to be misreported.
     /// @param timestamp Timestamp used in the signature
-    function timestampIsValid(uint256 timestamp) internal view returns (bool) {
-        unchecked {
-            return
-                timestamp + 1 hours > block.timestamp &&
-                timestamp < block.timestamp + 15 minutes;
-        }
-    }
+    function timestampIsValid(
+        uint256 timestamp
+    ) internal view virtual returns (bool);
 }

--- a/contracts/protocol/mock/MockAirnodeRequester.sol
+++ b/contracts/protocol/mock/MockAirnodeRequester.sol
@@ -85,4 +85,18 @@ contract MockAirnodeRequester is AirnodeRequester {
     ) external view onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         while (true) {}
     }
+
+    /// @notice Overriden to reject signatures that have been signed 1 hour
+    /// before or after `block.timestamp`
+    /// @dev The validation scheme implemented here is an arbitrary example. Do
+    /// not treat it as a recommendation. Refer to AirnodeRequester for more
+    /// information.
+    /// @param timestamp Timestamp used in the signature
+    function timestampIsValid(
+        uint256 timestamp
+    ) internal view virtual override returns (bool) {
+        return
+            timestamp + 1 hours > block.timestamp &&
+            timestamp < block.timestamp + 1 hours;
+    }
 }

--- a/contracts/protocol/mock/MockSponsor.sol
+++ b/contracts/protocol/mock/MockSponsor.sol
@@ -19,4 +19,10 @@ contract MockSponsor is AirnodeRequester {
     function claimBalance() external {
         IAirnodeProtocol(airnodeProtocol).claimBalance();
     }
+
+    function timestampIsValid(
+        uint256
+    ) internal view virtual override returns (bool) {
+        return true;
+    }
 }


### PR DESCRIPTION
Addresses API3-03

- Since signed data can no longer be used to update Beacon sets without updating the respective Beacon, and updating the respective Beacon is only allowed if doing so increases its timestamp, we no longer need to invalidate old signatures. Omitting this validation is consistent with any old Beacon being usable to update a Beacon set.
- Removes the timestamp validation implementation in AirnodeRequester and tells the user to implement it themselves
- Increases the tolerance for timestamps from the future from 15 minutes to 1 hour. This was previously set at the low value of 15 minutes because using mean for timestamp aggregation enabled some attack scenarios. Now that we are using median for timestamp aggregation, a minority attacker group reporting large timestamps will not affect the aggregated timestamp, which means we can relax this tolerance to a more accommodating range.