### PR TITLE
Add notices about proxy constructor argument validation

### DIFF
--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -5,6 +5,10 @@ import "./interfaces/IDapiProxy.sol";
 
 /// @title An immutable proxy contract that is used to read a specific dAPI of
 /// a specific DapiServer contract
+/// @notice In an effort to reduce the bytecode of this contract, its
+/// constructor arguments are validated by ProxyFactory, rather than
+/// internally. If you intend to deploy this contract without using
+/// ProxyFactory, you are recommended to implement an equivalent validation.
 /// @dev The proxy contracts are generalized to support most types of numerical
 /// data feeds. This means that the user of this proxy is expected to validate
 /// the read values according to the specific use-case. For example, `value` is

--- a/contracts/dapis/proxies/DapiProxyWithOev.sol
+++ b/contracts/dapis/proxies/DapiProxyWithOev.sol
@@ -7,6 +7,10 @@ import "./interfaces/IOevProxy.sol";
 /// @title An immutable proxy contract that is used to read a specific dAPI of
 /// a specific DapiServer contract and inform DapiServer about the beneficiary
 /// of the respective OEV proceeds
+/// @notice In an effort to reduce the bytecode of this contract, its
+/// constructor arguments are validated by ProxyFactory, rather than
+/// internally. If you intend to deploy this contract without using
+/// ProxyFactory, you are recommended to implement an equivalent validation.
 /// @dev See DapiProxy.sol for comments about usage
 contract DapiProxyWithOev is DapiProxy, IOevProxy {
     /// @notice OEV beneficiary address

--- a/contracts/dapis/proxies/DataFeedProxy.sol
+++ b/contracts/dapis/proxies/DataFeedProxy.sol
@@ -5,6 +5,10 @@ import "./interfaces/IDataFeedProxy.sol";
 
 /// @title An immutable proxy contract that is used to read a specific data
 /// feed (Beacon or Beacon set) of a specific DapiServer contract
+/// @notice In an effort to reduce the bytecode of this contract, its
+/// constructor arguments are validated by ProxyFactory, rather than
+/// internally. If you intend to deploy this contract without using
+/// ProxyFactory, you are recommended to implement an equivalent validation.
 /// @dev See DapiProxy.sol for comments about usage
 contract DataFeedProxy is IDataFeedProxy {
     /// @notice DapiServer address

--- a/contracts/dapis/proxies/DataFeedProxyWithOev.sol
+++ b/contracts/dapis/proxies/DataFeedProxyWithOev.sol
@@ -7,6 +7,10 @@ import "./interfaces/IOevProxy.sol";
 /// @title An immutable proxy contract that is used to read a specific data
 /// feed (Beacon or Beacon set) of a specific DapiServer contract and inform
 /// DapiServer about the beneficiary of the respective OEV proceeds
+/// @notice In an effort to reduce the bytecode of this contract, its
+/// constructor arguments are validated by ProxyFactory, rather than
+/// internally. If you intend to deploy this contract without using
+/// ProxyFactory, you are recommended to implement an equivalent validation.
 /// @dev See DapiProxy.sol for comments about usage
 contract DataFeedProxyWithOev is DataFeedProxy, IOevProxy {
     /// @notice OEV beneficiary address


### PR DESCRIPTION
Addresses API3-05

Since we deploy proxies as regular contracts for reduced external call overhead, we want to keep their bytecode small. Therefore, instead of adding checks in them, I added a notice to each of them to warn the user about this issue.