### PR TITLE
Populate returndata of tryExternalMulticall() to EOA

### DIFF
--- a/contracts/utils/ExternalMulticall.sol
+++ b/contracts/utils/ExternalMulticall.sol
@@ -75,6 +75,11 @@ contract ExternalMulticall is IExternalMulticall {
                 (successes[ind], returndata[ind]) = targets[ind].call(
                     data[ind]
                 );
+            } else {
+                returndata[ind] = abi.encodeWithSignature(
+                    "Error(string)",
+                    "Multicall target not contract"
+                );
             }
             unchecked {
                 ind++;

--- a/test/utils/ExternalMulticall.sol.js
+++ b/test/utils/ExternalMulticall.sol.js
@@ -205,7 +205,7 @@ describe('ExternalMulticall', function () {
           const { successes, returndata } = await externalMulticall.callStatic.tryExternalMulticall(targets, data);
           expect(successes).to.deep.equal([true, false, true]);
           expect(ethers.utils.defaultAbiCoder.decode(['int256'], returndata[0])[0]).to.equal(-1);
-          expect(returndata[1]).to.equal('0x');
+          expect(testUtils.decodeRevertString(returndata[1])).to.equal('Multicall target not contract');
           expect(ethers.utils.defaultAbiCoder.decode(['int256'], returndata[2])[0]).to.equal(-3);
           await expect(externalMulticall.tryExternalMulticall(targets, data)).to.not.be.reverted;
           expect(await multicallTarget.argumentHistory()).to.deep.equal([1, 3]);


### PR DESCRIPTION
Addresses API3-07

Populates the returndata of `tryExternalMulticall()` calls to EOAs in a way consistent with how `externalMulticall()` calls to EOAs revert