### PR TITLE
Make ExternalMulticall abstract and add guidance

### DIFF
--- a/contracts/utils/ExternalMulticall.sol
+++ b/contracts/utils/ExternalMulticall.sol
@@ -12,12 +12,12 @@ import "./interfaces/IExternalMulticall.sol";
 /// calls reverting.
 /// @dev As mentioned above, this contract can be used to interact with trusted
 /// contracts. Such interactions can leave this contract in a privileged
-/// position (e.g., with a non-zero balance of an ERC20 token), which can be
-/// abused by an attacker afterwards. In addition, attackers can frontrun
-/// interactions to have the following interaction result in an unintended
-/// outcome. A general solution to these attacks is overriding both multicall
-/// functions behind an access control mechanism, such as an `onlyOwner`
-/// modifier.
+/// position (e.g., ExternalMulticall may be left with a non-zero balance of an
+/// ERC20 token as a result of a transaction sent to it), which can be abused
+/// by an attacker afterwards. In addition, attackers can frontrun interactions
+/// to have the following interaction result in an unintended outcome. A
+/// general solution to these attacks is overriding both multicall functions
+/// behind an access control mechanism, such as an `onlyOwner` modifier.
 /// Refer to MakerDAO's Multicall.sol for a similar implementation.
 abstract contract ExternalMulticall is IExternalMulticall {
     /// @notice Batches calls to external contracts and reverts if at

--- a/contracts/utils/mock/MockExternalMulticall.sol
+++ b/contracts/utils/mock/MockExternalMulticall.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../ExternalMulticall.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+// This contract overrides the multicall functions to demonstrate how they can
+// be extended to only allow the owner to execute multicalls. However, we
+// only do that in comments because we want to test the vanilla contract.
+contract MockExternalMulticall is ExternalMulticall, Ownable {
+    function externalMulticall(
+        address[] calldata targets,
+        bytes[] calldata data
+    ) public virtual override returns (bytes[] memory returndata) {
+        // _checkOwner();
+        return super.externalMulticall(targets, data);
+    }
+
+    function tryExternalMulticall(
+        address[] calldata targets,
+        bytes[] calldata data
+    )
+        public
+        virtual
+        override
+        returns (bool[] memory successes, bytes[] memory returndata)
+    {
+        // _checkOwner();
+        return super.tryExternalMulticall(targets, data);
+    }
+}

--- a/test/utils/ExternalMulticall.sol.js
+++ b/test/utils/ExternalMulticall.sol.js
@@ -9,7 +9,7 @@ describe('ExternalMulticall', function () {
     const roles = {
       deployer: accounts[0],
     };
-    const ExternalMulticallFactory = await ethers.getContractFactory('ExternalMulticall', roles.deployer);
+    const ExternalMulticallFactory = await ethers.getContractFactory('MockExternalMulticall', roles.deployer);
     const externalMulticall = await ExternalMulticallFactory.deploy();
     const MockMulticallTargetFactory = await ethers.getContractFactory('MockMulticallTarget', roles.deployer);
     const multicallTarget = await MockMulticallTargetFactory.deploy();


### PR DESCRIPTION
Addresses API3-09

- Added some guidance to ExternalMulticall
- Made ExternalMulticall abstract so that it's a bit more difficult to deploy as it is and use it in a wrong way