### PR TITLE
Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ yarn test:coverage
 yarn test:gas
 ```
 
+## Solidity versions
+
+The current form of the repo is tested with Solidity version `0.8.17`. The complete contracts to be deployed are locked
+at this version, and the rest (interfaces, stub contracts, mock contracts) specify version `^0.8.0` to not limit their
+users. Some mock contracts use custom errors, which is why they specify version `^0.8.4`.
+
 ## Overview
 
 - `access-control-registry/`: Contracts typically implement standalone access control schemes, ranging from inheriting

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ users. Some mock contracts use custom errors, which is why they specify version 
   "data feeds"). Finally, _dAPIs_ are names that are attached to Beacons or Beacon sets, which can be seen as
   API3-managed data feeds. `DapiServer` uses RRP and PSP to update data feeds, which makes this contract a very good
   example of how the Airnode protocol can be used. In addition, `DapiServer` allows data signed by the respective
-  Airnodes to update data feeds, which can be delivered outside of the protocol. This is especially useful for Beacon
-  set updates, which the Airnode protocol is not suitable for because it is designed to have the Airnode interact with
-  the chain directly. Finally, a special version of these signed data updates are used to capture
+  Airnodes to update Beacons, which can be delivered outside of the protocol. Finally, a special version of these signed
+  data updates are used to capture
   [oracle extractable value (OEV)](https://medium.com/api3/oracle-extractable-value-oev-13c1b6d53c5b).
 
 - `utils/`: As the name suggests, utility contracts that the other contracts may require. Multicall contracts are aimed
@@ -113,10 +112,10 @@ relay, or requiring to interact with other oracle nodes through a blockchain or 
 unacceptable for the trust-minimized solution, as this introduces additional points of failure.
 
 An example of this can be seen in `DapiServer`, where Beacon sets are updated by collecting signed data from Airnodes
-and calling `updateDataFeedWithSignedData()` by a centralized agent. In the event that this service stops, Airnodes can
-update their respective Beacons by calling `fulfillPspBeaconUpdate()` if they have PSP subscriptions, or they can use
-`updateDataFeedWithSignedData()` only with their own signed data to update their respective Beacon (as
-[byog](https://byog.io/) does), after which the Beacon set can be updated by anyone by calling
+and calling `updateBeaconWithSignedData()` and `updateBeaconSetWithBeacons()` by a centralized agent. In the event that
+this service stops, Airnodes can update their respective Beacons by calling `fulfillPspBeaconUpdate()` if they have PSP
+subscriptions, or they can use `updateDataFeedWithSignedData()` only with their own signed data to update their
+respective Beacon (as [byog](https://byog.io/) does), after which the Beacon set can be updated by anyone by calling
 `updateBeaconSetWithBeacons()` or through a PSP subscription that will call `fulfillPspBeaconSetUpdate()` based on
 deviation conditions. The latter method of doing things is not expected to be used, yet it existing as a failsafe makes
 the former method acceptable.

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -535,14 +535,13 @@ contract DapiServer is
     /// Even if this function returns `true`, the respective Subscription
     /// fulfillment will fail if will not update the Beacon set value or
     /// timestamp.
-    /// @param subscriptionId Subscription ID
     /// @param data Fulfillment data (array of Beacon IDs, i.e., `bytes32[]`
     /// encoded in contract ABI)
     /// @param conditionParameters Subscription condition parameters. This
     /// includes multiple ABI-encoded values, see `checkUpdateCondition()`.
     /// @return If the Beacon set update subscription should be fulfilled
     function conditionPspBeaconSetUpdate(
-        bytes32 subscriptionId, // solhint-disable-line no-unused-vars
+        bytes32,
         bytes calldata data,
         bytes calldata conditionParameters
     ) external view override returns (bool) {
@@ -576,23 +575,15 @@ contract DapiServer is
     /// a standard implementation of Airnode is being used, these can be
     /// expected to be correct. Either way, the assumption is that it does not
     /// matter for the purposes of a Beacon set update subscription.
-    /// @param subscriptionId Subscription ID
-    /// @param airnode Airnode address
-    /// @param relayer Relayer address
-    /// @param sponsor Sponsor address
-    /// @param timestamp Timestamp used in the signature
     /// @param data Fulfillment data (an `int256` encoded in contract ABI)
-    /// @param signature Subscription ID, timestamp, sponsor wallet address
-    /// (and fulfillment data if the relayer is not the Airnode) signed by the
-    /// Airnode wallet
     function fulfillPspBeaconSetUpdate(
-        bytes32 subscriptionId, // solhint-disable-line no-unused-vars
-        address airnode, // solhint-disable-line no-unused-vars
-        address relayer, // solhint-disable-line no-unused-vars
-        address sponsor, // solhint-disable-line no-unused-vars
-        uint256 timestamp, // solhint-disable-line no-unused-vars
+        bytes32,
+        address,
+        address,
+        address,
+        uint256,
         bytes calldata data,
-        bytes calldata signature // solhint-disable-line no-unused-vars
+        bytes calldata
     ) external override {
         require(
             keccak256(data) ==

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -401,7 +401,10 @@ contract DapiServer is
     /// @notice Returns if the respective Beacon needs to be updated based on
     /// the fulfillment data and the condition parameters
     /// @dev `conditionParameters` are specified within the `conditions` field
-    /// of a Subscription
+    /// of a Subscription.
+    /// Even if this function returns `true`, the respective Subscription
+    /// fulfillment will fail if the Beacon is updated with a larger timestamp
+    /// in the meantime.
     /// @param subscriptionId Subscription ID
     /// @param data Fulfillment data (an `int256` encoded in contract ABI)
     /// @param conditionParameters Subscription condition parameters. This
@@ -414,9 +417,6 @@ contract DapiServer is
     ) external view override returns (bool) {
         bytes32 beaconId = subscriptionIdToBeaconId[subscriptionId];
         require(beaconId != bytes32(0), "Subscription not registered");
-        // Assuming that the update value will be signed after this condition
-        // returns true, the update timestamp will be larger than
-        // `block.timestamp`, which will still satisfy the update condition.
         return
             checkUpdateCondition(
                 beaconId,
@@ -429,7 +429,8 @@ contract DapiServer is
     /// @notice Called by the Airnode/relayer using the sponsor wallet to
     /// fulfill the Beacon update subscription
     /// @dev There is no need to verify that `conditionPspBeaconUpdate()`
-    /// returns `true` because any Beacon update is a good Beacon update
+    /// returns `true` because any Beacon update is a good Beacon update as
+    /// long as it increases the timestamp
     /// @param subscriptionId Subscription ID
     /// @param airnode Airnode address
     /// @param relayer Relayer address
@@ -531,6 +532,9 @@ contract DapiServer is
     /// to be zero, which means the `parameters` field of the Subscription will
     /// be forwarded to this function as `data`. This field should be the
     /// Beacon ID array encoded in contract ABI.
+    /// Even if this function returns `true`, the respective Subscription
+    /// fulfillment will fail if will not update the Beacon set value or
+    /// timestamp.
     /// @param subscriptionId Subscription ID
     /// @param data Fulfillment data (array of Beacon IDs, i.e., `bytes32[]`
     /// encoded in contract ABI)
@@ -971,9 +975,6 @@ contract DapiServer is
     }
 
     /// @notice Called privately to aggregate the Beacons and return the result
-    /// @dev Tha aggregation of Beacons may have a different value than the
-    /// respective Beacon set, e.g., because the Beacon set has been updated
-    /// using signed data
     /// @param beaconIds Beacon IDs
     /// @return value Aggregation value
     /// @return timestamp Aggregation timestamp

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -535,13 +535,14 @@ contract DapiServer is
     /// Even if this function returns `true`, the respective Subscription
     /// fulfillment will fail if will not update the Beacon set value or
     /// timestamp.
+    /// @param // subscriptionId Subscription ID
     /// @param data Fulfillment data (array of Beacon IDs, i.e., `bytes32[]`
     /// encoded in contract ABI)
     /// @param conditionParameters Subscription condition parameters. This
     /// includes multiple ABI-encoded values, see `checkUpdateCondition()`.
     /// @return If the Beacon set update subscription should be fulfilled
     function conditionPspBeaconSetUpdate(
-        bytes32,
+        bytes32 /* subscriptionId */,
         bytes calldata data,
         bytes calldata conditionParameters
     ) external view override returns (bool) {
@@ -575,15 +576,23 @@ contract DapiServer is
     /// a standard implementation of Airnode is being used, these can be
     /// expected to be correct. Either way, the assumption is that it does not
     /// matter for the purposes of a Beacon set update subscription.
+    /// @param // subscriptionId Subscription ID
+    /// @param // airnode Airnode address
+    /// @param // relayer Relayer address
+    /// @param // sponsor Sponsor address
+    /// @param // timestamp Timestamp used in the signature
     /// @param data Fulfillment data (an `int256` encoded in contract ABI)
+    /// @param // signature Subscription ID, timestamp, sponsor wallet address
+    /// (and fulfillment data if the relayer is not the Airnode) signed by the
+    /// Airnode wallet
     function fulfillPspBeaconSetUpdate(
-        bytes32,
-        address,
-        address,
-        address,
-        uint256,
+        bytes32 /* subscriptionId */,
+        address /* airnode */,
+        address /* relayer */,
+        address /* sponsor */,
+        uint256 /* timestamp */,
         bytes calldata data,
-        bytes calldata
+        bytes calldata /* signature */
     ) external override {
         require(
             keccak256(data) ==

--- a/contracts/dapis/QuickSelect.sol
+++ b/contracts/dapis/QuickSelect.sol
@@ -35,7 +35,13 @@ contract Quickselect {
         uint256 arrayLength = array.length;
         assert(arrayLength > 1);
         unchecked {
-            return quickselect(array, 0, arrayLength - 1, k, true);
+            (indK, indKPlusOne) = quickselect(
+                array,
+                0,
+                arrayLength - 1,
+                k,
+                true
+            );
         }
     }
 

--- a/contracts/dapis/QuickSelect.sol
+++ b/contracts/dapis/QuickSelect.sol
@@ -86,7 +86,8 @@ contract Quickselect {
             unchecked {
                 i = indKPlusOne + 1;
             }
-            for (; i < array.length; ) {
+            uint256 arrayLength = array.length;
+            for (; i < arrayLength; ) {
                 if (array[i] < array[indKPlusOne]) {
                     indKPlusOne = i;
                 }

--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./interfaces/IDapiProxy.sol";
+import "../interfaces/IDapiServer.sol";
 
 /// @title An immutable proxy contract that is used to read a specific dAPI of
 /// a specific DapiServer contract

--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -19,7 +19,7 @@ import "../interfaces/IDapiServer.sol";
 /// In the case that the data feed is from a single source, `timestamp` is the
 /// system time of the Airnode when it signed the data. In the case that the
 /// data feed is from multiple sources, `timestamp` is the median of system
-/// times of the respective Airnodes when they signed the data. There are two
+/// times of the Airnodes when they signed the respective data. There are two
 /// points to consider while using `timestamp` in your contract logic: (1) It
 /// is based on the system time of the Airnodes, and not the block timestamp.
 /// This may be relevant when either of them drifts. (2) `timestamp` is an

--- a/contracts/dapis/proxies/DataFeedProxy.sol
+++ b/contracts/dapis/proxies/DataFeedProxy.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./interfaces/IDataFeedProxy.sol";
+import "../interfaces/IDapiServer.sol";
 
 /// @title An immutable proxy contract that is used to read a specific data
 /// feed (Beacon or Beacon set) of a specific DapiServer contract

--- a/contracts/dapis/proxies/interfaces/IProxy.sol
+++ b/contracts/dapis/proxies/interfaces/IProxy.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "../../interfaces/IDapiServer.sol";
-
+/// @dev See DapiProxy.sol for comments about usage
 interface IProxy {
     function read() external view returns (int224 value, uint32 timestamp);
 

--- a/contracts/protocol/StorageUtils.sol
+++ b/contracts/protocol/StorageUtils.sol
@@ -5,9 +5,9 @@ import "./interfaces/IStorageUtils.sol";
 
 /// @title Contract that stores template and subscription details on chain
 /// @notice The Airnode protocol does not depend on the template or
-/// subscription details being announced or stored on-chain. Airnode can be
-/// informed about these in other ways, e.g., the details are hardcoded in the
-/// Airnode configuration file.
+/// subscription details being stored on-chain. Airnode can be informed about
+/// these in other ways, e.g., the details are hardcoded in the Airnode
+/// configuration file.
 contract StorageUtils is IStorageUtils {
     struct Template {
         bytes32 endpointId;

--- a/contracts/protocol/WithdrawalUtils.sol
+++ b/contracts/protocol/WithdrawalUtils.sol
@@ -32,7 +32,12 @@ contract WithdrawalUtils is IWithdrawalUtils {
 
     mapping(bytes32 => bytes32) private withdrawalRequestIdToParameters;
 
-    /// @notice Called by a sponsor to request a withdrawal
+    /// @notice Called by a sponsor to request a withdrawal. In response, the
+    /// Airnode/relayer is expected to deposit the funds at this contract by
+    /// calling `fulfillWithdrawal()`, and then the sponsor will have to call
+    /// `claimBalance()` to have the funds sent to itself. For sponsor to be
+    /// able to receive funds this way, it has to be an EOA or a contract that
+    /// has an appropriate payable fallback function.
     /// @param airnodeOrRelayer Airnode/relayer address
     /// @param protocolId Protocol ID
     function requestWithdrawal(

--- a/contracts/protocol/WithdrawalUtils.sol
+++ b/contracts/protocol/WithdrawalUtils.sol
@@ -89,7 +89,7 @@ contract WithdrawalUtils is IWithdrawalUtils {
         unchecked {
             require(
                 timestamp + 1 hours > block.timestamp &&
-                    timestamp < block.timestamp + 15 minutes,
+                    timestamp < block.timestamp + 1 hours,
                 "Timestamp not valid"
             );
         }

--- a/contracts/protocol/mock/MockAirnodeRequester.sol
+++ b/contracts/protocol/mock/MockAirnodeRequester.sol
@@ -52,36 +52,30 @@ contract MockAirnodeRequester is AirnodeRequester {
 
     /// @notice A method to be called back by the respective method at
     /// AirnodeRrp.sol for testing fulfillment failure
-    /// @param requestId Request ID
-    /// @param data Data returned by the Airnode
     function fulfillRequestAlwaysReverts(
-        bytes32 requestId, // solhint-disable-line no-unused-vars
+        bytes32,
         uint256 timestamp,
-        bytes calldata data // solhint-disable-line no-unused-vars
+        bytes calldata
     ) external view onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         revert("Always reverts");
     }
 
     /// @notice A method to be called back by the respective method at
     /// AirnodeRrp.sol for testing fulfillment failure
-    /// @param requestId Request ID
-    /// @param data Data returned by the Airnode
     function fulfillRequestAlwaysRevertsWithNoString(
-        bytes32 requestId, // solhint-disable-line no-unused-vars
+        bytes32,
         uint256 timestamp,
-        bytes calldata data // solhint-disable-line no-unused-vars
+        bytes calldata
     ) external view onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         revert(); // solhint-disable-line reason-string
     }
 
     /// @notice A method to be called back by the respective method at
     /// AirnodeRrp.sol for testing fulfillment running out of gas
-    /// @param requestId Request ID
-    /// @param data Data returned by the Airnode
     function fulfillRequestAlwaysRunsOutOfGas(
-        bytes32 requestId, // solhint-disable-line no-unused-vars
+        bytes32,
         uint256 timestamp,
-        bytes calldata data // solhint-disable-line no-unused-vars
+        bytes calldata
     ) external view onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         while (true) {}
     }

--- a/contracts/protocol/mock/MockAirnodeRequester.sol
+++ b/contracts/protocol/mock/MockAirnodeRequester.sol
@@ -52,30 +52,39 @@ contract MockAirnodeRequester is AirnodeRequester {
 
     /// @notice A method to be called back by the respective method at
     /// AirnodeRrp.sol for testing fulfillment failure
+    /// @param // requestId Request ID
+    /// @param timestamp Timestamp used in the signature
+    /// @param // data Data returned by the Airnode
     function fulfillRequestAlwaysReverts(
-        bytes32,
+        bytes32 /* requestId */,
         uint256 timestamp,
-        bytes calldata
+        bytes calldata /* data */
     ) external view onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         revert("Always reverts");
     }
 
     /// @notice A method to be called back by the respective method at
     /// AirnodeRrp.sol for testing fulfillment failure
+    /// @param // requestId Request ID
+    /// @param timestamp Timestamp used in the signature
+    /// @param // data Data returned by the Airnode
     function fulfillRequestAlwaysRevertsWithNoString(
-        bytes32,
+        bytes32 /* requestId */,
         uint256 timestamp,
-        bytes calldata
+        bytes calldata /* data */
     ) external view onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         revert(); // solhint-disable-line reason-string
     }
 
     /// @notice A method to be called back by the respective method at
     /// AirnodeRrp.sol for testing fulfillment running out of gas
+    /// @param // requestId Request ID
+    /// @param timestamp Timestamp used in the signature
+    /// @param // data Data returned by the Airnode
     function fulfillRequestAlwaysRunsOutOfGas(
-        bytes32,
+        bytes32 /* requestId */,
         uint256 timestamp,
-        bytes calldata
+        bytes calldata /* data */
     ) external view onlyAirnodeProtocol onlyValidTimestamp(timestamp) {
         while (true) {}
     }

--- a/contracts/utils/ExternalMulticall.sol
+++ b/contracts/utils/ExternalMulticall.sol
@@ -20,8 +20,8 @@ import "./interfaces/IExternalMulticall.sol";
 /// modifier.
 /// Refer to MakerDAO's Multicall.sol for a similar implementation.
 abstract contract ExternalMulticall is IExternalMulticall {
-    /// @notice Batches calls to external contracts and reverts if at
-    /// least one of the batched calls reverts
+    /// @notice Batches calls to external contracts and reverts as soon as one
+    /// of the batched calls reverts
     /// @param targets Array of target addresses of batched calls
     /// @param data Array of calldata of batched calls
     /// @return returndata Array of returndata of batched calls

--- a/contracts/utils/SelfMulticall.sol
+++ b/contracts/utils/SelfMulticall.sol
@@ -12,8 +12,8 @@ import "./interfaces/ISelfMulticall.sol";
 /// functions that use internal/private visibility modifiers.
 /// Refer to OpenZeppelin's Multicall.sol for a similar implementation.
 contract SelfMulticall is ISelfMulticall {
-    /// @notice Batches calls to the inheriting contract and reverts if at
-    /// least one of the batched calls reverts
+    /// @notice Batches calls to the inheriting contract and reverts as soon as
+    /// one of the batched calls reverts
     /// @param data Array of calldata of batched calls
     /// @return returndata Array of returndata of batched calls
     function multicall(

--- a/test/protocol/WithdrawalUtils.sol.js
+++ b/test/protocol/WithdrawalUtils.sol.js
@@ -266,7 +266,7 @@ describe('WithdrawalUtils', function () {
 
           const nextTimestamp2 = (await helpers.time.latest()) + 1;
           await helpers.time.setNextBlockTimestamp(nextTimestamp2);
-          const timestampFromFuture = nextTimestamp + 15 * 60 + 1;
+          const timestampFromFuture = nextTimestamp + 60 * 60 + 1;
           const signatureFromFuture = await roles.airnode.signMessage(
             ethers.utils.arrayify(
               ethers.utils.solidityKeccak256(


### PR DESCRIPTION
Addresses API3-12, selectively

What I didn't address:
- The typecasting is indeed surprisingly expensive (~50 gas based on my tests). However, in addition to struct-packing reasons, using `uint32` in interfaces is useful in that it enforces additional type checks. There are only a few points where this optimization makes sense (because a lot of the time the timestamp will needed to be packed in a struct), and imo they are not worth creating special cases.
- We avoid custom errors because we may deploy on weird chains with custom block explorers that don't support them. We're not overly concerned about deployment costs (because our contracts are deployed once per chain) and optimizing the gas cost of the reverting branch is not a significant concern.
- We don't see a reason to limit role description lengths to 32 characters, and some of our role description lengths are already longer than that. Also, the fact that they are of string type is only a gas cost issue because we decided to provide the full role descriptions on-chain (because we will deploy these only once per chain so the additional gas cost is worth it). An AccessControlRegistry user implementation that is concerned about the additional gas cost should hardcode the description hashes instead.
- Dividing `require()` conditions that will result in the same error message being emitted reduces readability and the gas cost saving isn't worth it.