### PR TITLE
Reworks OEV to aggregate off chain

### DIFF
--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -636,119 +636,117 @@ contract DapiServer is
 
     ///                     ~~~OEV~~~
 
-    /// @notice Updates a data feed that the OEV proxy reads using data signed
-    /// by the respective Airnodes for the specific bid. The Beacons for which
-    /// the fulfillment data and signature is omitted will be read from
-    /// storage.
-    /// @dev Even though data for Beacons are signed individually, the caller
-    /// is only allowed to use the signatures as a bundle. They cannot omit
-    /// individual signatures or mix-and-match among bundles.
+    /// @notice Updates a data feed that the OEV proxy reads using the
+    /// aggregation signed by the absolute majority of the respective Airnodes
+    /// for the specific bid
+    /// @dev For when the data feed being updated is a Beacon set, an absolute
+    /// majority of Airnodes must sign the resulting value and timestamp. While
+    /// doing so, Airnodes should refer to data signed by the respective
+    /// Airnodes. The absolute majority of this signed data should have similar
+    /// timestamps and values (e.g., within 2 minutes and 1% deviation).
+    /// Freshness should not be required, as OEV proxy data feeds cannot be
+    /// updated using older timestamps.
     /// @param oevProxy OEV proxy that reads the data feed
+    /// @param dataFeedId Data feed ID
     /// @param updateId Update ID
-    /// @param signatureCount Number of signatures in `signedData`
-    /// @param signedData Array of ABI-encoded Airnode address, template ID,
-    /// timestamp, fulfillment data and bid metadata that is signed by the
-    /// respective Airnode for the specific bid
+    /// @param timestamp Signature timestamp
+    /// @param data Update data (an `int256` encoded in contract ABI)
+    /// @param packedOevUpdateSignatures Packed OEV update signatures, which
+    /// include the Airnode address, template ID and these signed with the OEV
+    /// update hash
     function updateOevProxyDataFeedWithSignedData(
         address oevProxy,
+        bytes32 dataFeedId,
         bytes32 updateId,
-        uint256 signatureCount,
-        bytes[] calldata signedData
-    ) external payable override {
-        uint256 beaconCount = signedData.length;
-        bytes32 metadataHash = keccak256(
+        uint256 timestamp,
+        bytes calldata data,
+        bytes[] calldata packedOevUpdateSignatures
+    ) external payable override onlyValidTimestamp(timestamp) {
+        require(
+            timestamp > oevProxyToIdToDataFeed[oevProxy][dataFeedId].timestamp,
+            "Does not update timestamp"
+        );
+        bytes32 oevUpdateHash = keccak256(
             abi.encodePacked(
                 block.chainid,
                 address(this),
-                address(oevProxy),
-                msg.sender,
-                msg.value,
+                oevProxy,
+                dataFeedId,
                 updateId,
-                signatureCount,
-                beaconCount
+                timestamp,
+                data,
+                msg.sender,
+                msg.value
             )
         );
+        int224 updatedValue = decodeFulfillmentData(data);
+        uint32 updatedTimestamp = uint32(timestamp);
+        uint256 beaconCount = packedOevUpdateSignatures.length;
         if (beaconCount > 1) {
             bytes32[] memory beaconIds = new bytes32[](beaconCount);
-            int256[] memory values = new int256[](beaconCount);
-            uint256 accumulatedTimestamp = 0;
+            uint256 validSignatureCount;
             for (uint256 ind = 0; ind < beaconCount; ) {
+                bool signatureIsNotOmitted;
                 (
-                    bytes32 beaconId,
-                    int224 beaconValue,
-                    uint32 beaconTimestamp
-                ) = decodeOevSignedData(metadataHash, signedData[ind]);
-                beaconIds[ind] = beaconId;
-                if (beaconTimestamp != 0) {
-                    values[ind] = beaconValue;
+                    signatureIsNotOmitted,
+                    beaconIds[ind]
+                ) = unpackAndValidateOevUpdateSignature(
+                    oevUpdateHash,
+                    packedOevUpdateSignatures[ind]
+                );
+                if (signatureIsNotOmitted) {
                     unchecked {
-                        accumulatedTimestamp += beaconTimestamp;
-                    }
-                    require(signatureCount != 0, "More signatures than stated");
-                    unchecked {
-                        signatureCount--;
-                    }
-                } else {
-                    DataFeed storage beacon = dataFeeds[beaconId];
-                    values[ind] = beacon.value;
-                    unchecked {
-                        accumulatedTimestamp += beacon.timestamp;
+                        validSignatureCount++;
                     }
                 }
                 unchecked {
                     ind++;
                 }
             }
-            require(signatureCount == 0, "Less signatures than stated");
-            bytes32 beaconSetId = deriveBeaconSetId(beaconIds);
-            uint32 updatedTimestamp = uint32(
-                accumulatedTimestamp / beaconCount
+            // "Greater than or equal to" is not enough because full control
+            // of aggregation requires an absolute majority
+            require(
+                validSignatureCount > beaconCount / 2,
+                "Not enough signatures"
             );
             require(
-                updatedTimestamp >
-                    oevProxyToIdToDataFeed[oevProxy][beaconSetId].timestamp,
-                "Does not update timestamp"
+                dataFeedId == deriveBeaconSetId(beaconIds),
+                "Beacon set ID mismatch"
             );
-            int224 updatedValue = int224(median(values));
-            oevProxyToIdToDataFeed[oevProxy][beaconSetId] = DataFeed({
-                value: updatedValue,
-                timestamp: updatedTimestamp
-            });
-            oevProxyToBalance[oevProxy] += msg.value;
             emit UpdatedOevProxyBeaconSetWithSignedData(
-                beaconSetId,
+                dataFeedId,
                 oevProxy,
                 updateId,
                 updatedValue,
                 updatedTimestamp
             );
         } else if (beaconCount == 1) {
-            (
-                bytes32 beaconId,
-                int224 updatedValue,
-                uint32 updatedTimestamp
-            ) = decodeOevSignedData(metadataHash, signedData[0]);
-            require(updatedTimestamp != 0, "Missing data");
-            require(
-                updatedTimestamp >
-                    oevProxyToIdToDataFeed[oevProxy][beaconId].timestamp,
-                "Does not update timestamp"
-            );
-            oevProxyToIdToDataFeed[oevProxy][beaconId] = DataFeed({
-                value: updatedValue,
-                timestamp: updatedTimestamp
-            });
-            oevProxyToBalance[oevProxy] += msg.value;
+            {
+                (
+                    bool signatureIsNotOmitted,
+                    bytes32 beaconId
+                ) = unpackAndValidateOevUpdateSignature(
+                        oevUpdateHash,
+                        packedOevUpdateSignatures[0]
+                    );
+                require(signatureIsNotOmitted, "Missing signature");
+                require(dataFeedId == beaconId, "Beacon ID mismatch");
+            }
             emit UpdatedOevProxyBeaconWithSignedData(
-                beaconId,
+                dataFeedId,
                 oevProxy,
                 updateId,
                 updatedValue,
                 updatedTimestamp
             );
         } else {
-            revert("Specified no Beacons");
+            revert("Did not specify any Beacons");
         }
+        oevProxyToIdToDataFeed[oevProxy][dataFeedId] = DataFeed({
+            value: updatedValue,
+            timestamp: updatedTimestamp
+        });
+        oevProxyToBalance[oevProxy] += msg.value;
     }
 
     /// @notice Withdraws the balance of the OEV proxy to the respective
@@ -1029,54 +1027,31 @@ contract DapiServer is
             absoluteInitialValue;
     }
 
-    /// @notice Decodes data signed by the respective Airnode for the specific
-    /// bid to update the Beacon that a OEV proxy reads
-    /// @param metadataHash Hash of the metadata of the bid that won the OEV
-    /// auction
-    /// @param signedData ABI-encoded Airnode address, template ID, timestamp,
-    /// fulfillment data and bid metadata that is signed by the respective
-    /// Airnode for the specific bid
+    /// @notice Called privately to unpack and validate the OEV update
+    /// signature
+    /// @param oevUpdateHash OEV update hash
+    /// @param packedOevUpdateSignature Packed OEV update signature, which
+    /// includes the Airnode address, template ID and these signed with the OEV
+    /// update hash
+    /// @return signatureIsNotOmitted If the signature is omitted in
+    /// `packedOevUpdateSignature`
     /// @return beaconId Beacon ID
-    /// @return beaconValue Beacon value
-    /// @return beaconTimestamp Beacon timestamp
-    function decodeOevSignedData(
-        bytes32 metadataHash,
-        bytes calldata signedData
-    )
-        private
-        view
-        returns (bytes32 beaconId, int224 beaconValue, uint32 beaconTimestamp)
-    {
-        (
-            address airnode,
-            bytes32 templateId,
-            uint256 timestamp,
-            bytes memory data,
-            bytes memory signature
-        ) = abi.decode(signedData, (address, bytes32, uint256, bytes, bytes));
+    function unpackAndValidateOevUpdateSignature(
+        bytes32 oevUpdateHash,
+        bytes calldata packedOevUpdateSignature
+    ) private pure returns (bool signatureIsNotOmitted, bytes32 beaconId) {
+        (address airnode, bytes32 templateId, bytes memory signature) = abi
+            .decode(packedOevUpdateSignature, (address, bytes32, bytes));
         beaconId = deriveBeaconId(airnode, templateId);
-        if (signature.length == 0) {
-            require(data.length == 0, "Missing signature");
-        } else {
+        if (signature.length != 0) {
             require(
                 (
-                    keccak256(
-                        abi.encodePacked(
-                            metadataHash,
-                            templateId,
-                            timestamp,
-                            data
-                        )
-                    ).toEthSignedMessageHash()
+                    keccak256(abi.encodePacked(oevUpdateHash, templateId))
+                        .toEthSignedMessageHash()
                 ).recover(signature) == airnode,
                 "Signature mismatch"
             );
-            beaconValue = decodeFulfillmentData(data);
-            require(
-                timestamp != 0 && timestampIsValid(timestamp),
-                "Timestamp not valid"
-            );
-            beaconTimestamp = uint32(timestamp);
+            signatureIsNotOmitted = true;
         }
     }
 

--- a/contracts/dapis/DapiServer.sol
+++ b/contracts/dapis/DapiServer.sol
@@ -640,12 +640,13 @@ contract DapiServer is
     /// aggregation signed by the absolute majority of the respective Airnodes
     /// for the specific bid
     /// @dev For when the data feed being updated is a Beacon set, an absolute
-    /// majority of Airnodes must sign the resulting value and timestamp. While
-    /// doing so, Airnodes should refer to data signed by the respective
-    /// Airnodes. The absolute majority of this signed data should have similar
-    /// timestamps and values (e.g., within 2 minutes and 1% deviation).
-    /// Freshness should not be required, as OEV proxy data feeds cannot be
-    /// updated using older timestamps.
+    /// majority of the Airnodes that power the respective Beacons must sign
+    /// the aggregated value and timestamp. While doing so, the Airnodes should
+    /// refer to data signed to update an absolute majority of the respective
+    /// Beacons. The Airnodes should require the data to be fresh enough (e.g.,
+    /// at most 2 minutes-old), and tightly distributed around the resulting
+    /// aggregation (e.g., within 1% deviation), and reject to provide an OEV
+    /// proxy data feed update signature if these are not satisfied.
     /// @param oevProxy OEV proxy that reads the data feed
     /// @param dataFeedId Data feed ID
     /// @param updateId Update ID

--- a/contracts/dapis/interfaces/IDapiServer.sol
+++ b/contracts/dapis/interfaces/IDapiServer.sol
@@ -187,9 +187,11 @@ interface IDapiServer is IExtendedSelfMulticall, IAirnodeRequester {
 
     function updateOevProxyDataFeedWithSignedData(
         address oevProxy,
+        bytes32 dataFeedId,
         bytes32 updateId,
-        uint256 signatureCount,
-        bytes[] calldata signedData
+        uint256 timestamp,
+        bytes calldata data,
+        bytes[] calldata packedOevUpdateSignatures
     ) external payable;
 
     function withdraw(address oevProxy) external;

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -49,13 +49,6 @@ module.exports = {
       `m/44'/60'/0'/${deriveWalletPathFromSponsorAddress(sponsorAddress, protocolId)}`
     ).connect(ethers.provider);
   },
-  deriveSponsorshipId: (scheme, parameters) => {
-    if (scheme === 'Requester') {
-      return ethers.utils.keccak256(ethers.utils.solidityPack(['uint256', 'address'], [1, parameters.requester]));
-    } else {
-      throw new Error('Invalid sponsorship scheme');
-    }
-  },
   getCurrentTimestamp: async (provider) => {
     return (await provider.getBlock()).timestamp;
   },
@@ -200,16 +193,6 @@ module.exports = {
     return await airnode.signMessage(
       ethers.utils.arrayify(
         ethers.utils.solidityKeccak256(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, data])
-      )
-    );
-  },
-  domainSignData: async (airnode, dapiServer, templateId, timestamp, data) => {
-    return await airnode.signMessage(
-      ethers.utils.arrayify(
-        ethers.utils.solidityKeccak256(
-          ['uint256', 'address', 'bytes32', 'uint256', 'bytes'],
-          [(await dapiServer.provider.getNetwork()).chainId, dapiServer.address, templateId, timestamp, data]
-        )
       )
     );
   },

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -199,36 +199,31 @@ module.exports = {
   signOevData: async (
     dapiServer,
     oevProxyAddress,
+    dataFeedId,
+    updateId,
+    timestamp,
+    data,
     searcherAddress,
     bidAmount,
-    updateId,
-    signatureCount,
-    beaconCount,
     airnode,
-    templateId,
-    timestamp,
-    data
+    templateId
   ) => {
-    const metadataHash = ethers.utils.solidityKeccak256(
-      ['uint256', 'address', 'address', 'address', 'uint256', 'bytes32', 'uint256', 'uint256'],
+    const oevUpdateHash = ethers.utils.solidityKeccak256(
+      ['uint256', 'address', 'address', 'bytes32', 'bytes32', 'uint256', 'bytes', 'address', 'uint256'],
       [
         (await dapiServer.provider.getNetwork()).chainId,
         dapiServer.address,
         oevProxyAddress,
+        dataFeedId,
+        updateId,
+        timestamp,
+        data,
         searcherAddress,
         bidAmount,
-        updateId,
-        signatureCount,
-        beaconCount,
       ]
     );
     return await airnode.signMessage(
-      ethers.utils.arrayify(
-        ethers.utils.solidityKeccak256(
-          ['bytes32', 'bytes32', 'uint256', 'bytes'],
-          [metadataHash, templateId, timestamp, data]
-        )
-      )
+      ethers.utils.arrayify(ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [oevUpdateHash, templateId]))
     );
   },
 };


### PR DESCRIPTION
Addresses the OEV portion of API3-01

The solution for signed updates in https://github.com/api3dao/airnode-protocol-v1/pull/96 doesn't work well for OEV updates because Beacons specific to OEV proxies are not live Beacons, i.e., the respective Airnode cannot update these on its own despite being censored by the OEV relay. OEV updates are multi-party process, which can be piggybacked on for a nicer solution.

Considering that an absolute majority of Beacon sets would be able to fully control the aggregation, it doesn't degrade the security guarantees to allow them to do the aggregation off-chain and write the aggregated value to the chain (except as seen above, the aggregation requirements are slightly relaxed). This resolves API3-01 by pushing the timestamp-related checks from the chain to the node. The main concern here is providing enough information to the honest nodes to be able to confidently come up with an aggregation. The questions to ask are
- Did the other nodes actually report these values? This can be verified through signatures. 
- Were the other nodes being censored (as in, "am I being fed outdated data even though these nodes would have provided more up to date if asked")? This is impossible to prove without a trusted channel, which is why outdated data has to be rejected. There are two things to consider here
  - We only need to check if the data point is outdated relative to the other data points. The contract will decide if the resulting aggregation improves the freshness of the on-chain data point (this is nice because we don't need to worry about chain time drift). 
  - Even when not all data is up to date, if an absolute majority is largely consistent on both value and timestamp, an aggregation from these can be achieved up to a confidence relative to how consistent they are. We can't simply require the absolute majority of the data points to be up to date and aggregate, as an attacking minority may then become over-represented in this absolute majority. Therefore, OEV Beacon set updates require the absolute majority to agree on both value and timestamp.

In practice, the OEV signing API of Airnode will receive signed data from all Beacons of the Beacon set, verify the signatures, calculate the median of values and timestamps, verify that an absolute majority falls within a confidence interval of this median (for example, in a 2 minutes and 1% window), then signs the aggregation along with all the OEV parameters.