### PR TITLE
Adds containsBytecode()

### DIFF
--- a/contracts/utils/ExtendedSelfMulticall.sol
+++ b/contracts/utils/ExtendedSelfMulticall.sol
@@ -24,6 +24,18 @@ contract ExtendedSelfMulticall is SelfMulticall, IExtendedSelfMulticall {
         return account.balance;
     }
 
+    /// @notice Returns if the account contains bytecode
+    /// @dev An account not containing any bytecode does not indicate that it
+    /// is an EOA or it will not contain any bytecode in the future.
+    /// Contract construction and `SELFDESTRUCT` updates the bytecode at the
+    /// end of the transaction.
+    /// @return If the account contains bytecode
+    function containsBytecode(
+        address account
+    ) external view override returns (bool) {
+        return account.code.length > 0;
+    }
+
     /// @notice Returns the current block number
     /// @return Current block number
     function getBlockNumber() external view override returns (uint256) {

--- a/contracts/utils/interfaces/IExtendedSelfMulticall.sol
+++ b/contracts/utils/interfaces/IExtendedSelfMulticall.sol
@@ -8,6 +8,8 @@ interface IExtendedSelfMulticall is ISelfMulticall {
 
     function getBalance(address account) external view returns (uint256);
 
+    function containsBytecode(address account) external view returns (bool);
+
     function getBlockNumber() external view returns (uint256);
 
     function getBlockTimestamp() external view returns (uint256);

--- a/test/utils/ExtendedSelfMulticall.sol.js
+++ b/test/utils/ExtendedSelfMulticall.sol.js
@@ -23,6 +23,14 @@ describe('ExtendedSelfMulticall', function () {
     });
   });
 
+  describe('containsBytecode', function () {
+    it('returns if account contains bytecode', async function () {
+      const { roles, extendedSelfMulticall } = await helpers.loadFixture(deploy);
+      expect(await extendedSelfMulticall.containsBytecode(roles.deployer.address)).to.equal(false);
+      expect(await extendedSelfMulticall.containsBytecode(extendedSelfMulticall.address)).to.equal(true);
+    });
+  });
+
   describe('getBalance', function () {
     it('gets balance', async function () {
       const { roles, extendedSelfMulticall } = await helpers.loadFixture(deploy);


### PR DESCRIPTION
Closes https://github.com/api3dao/airnode-protocol-v1/issues/93

I figured I'd name the function to be less assertive than `isContract()`