### PR TITLE
Require all updates to update both the timestamp and the value

### DIFF
--- a/contracts/dapis/DataFeedServer.sol
+++ b/contracts/dapis/DataFeedServer.sol
@@ -116,10 +116,9 @@ contract DataFeedServer is ExtendedSelfMulticall, Median, IDataFeedServer {
         returns (int224 updatedBeaconValue)
     {
         updatedBeaconValue = decodeFulfillmentData(data);
-        require(
-            timestamp > _dataFeeds[beaconId].timestamp,
-            "Does not update timestamp"
-        );
+        DataFeed storage beacon = _dataFeeds[beaconId];
+        require(timestamp > beacon.timestamp, "Does not update timestamp");
+        require(updatedBeaconValue != beacon.value, "Does not update value");
         _dataFeeds[beaconId] = DataFeed({
             value: updatedBeaconValue,
             timestamp: uint32(timestamp)

--- a/contracts/dapis/DataFeedServer.sol
+++ b/contracts/dapis/DataFeedServer.sol
@@ -55,7 +55,9 @@ contract DataFeedServer is ExtendedSelfMulticall, Median, IDataFeedServer {
             updatedTimestamp > beaconSet.timestamp,
             "Does not update timestamp"
         );
-        require(updatedValue != beaconSet.value, "Does not update value");
+        if (beaconSet.timestamp != 0) {
+            require(updatedValue != beaconSet.value, "Does not update value");
+        }
         _dataFeeds[beaconSetId] = DataFeed({
             value: updatedValue,
             timestamp: updatedTimestamp

--- a/contracts/dapis/DataFeedServer.sol
+++ b/contracts/dapis/DataFeedServer.sol
@@ -117,7 +117,12 @@ contract DataFeedServer is ExtendedSelfMulticall, Median, IDataFeedServer {
         updatedBeaconValue = decodeFulfillmentData(data);
         DataFeed storage beacon = _dataFeeds[beaconId];
         require(timestamp > beacon.timestamp, "Does not update timestamp");
-        require(updatedBeaconValue != beacon.value, "Does not update value");
+        if (beacon.timestamp != 0) {
+            require(
+                updatedBeaconValue != beacon.value,
+                "Does not update value"
+            );
+        }
         _dataFeeds[beaconId] = DataFeed({
             value: updatedBeaconValue,
             timestamp: uint32(timestamp)

--- a/contracts/dapis/DataFeedServer.sol
+++ b/contracts/dapis/DataFeedServer.sol
@@ -51,12 +51,11 @@ contract DataFeedServer is ExtendedSelfMulticall, Median, IDataFeedServer {
         );
         beaconSetId = deriveBeaconSetId(beaconIds);
         DataFeed storage beaconSet = _dataFeeds[beaconSetId];
-        if (beaconSet.timestamp == updatedTimestamp) {
-            require(
-                beaconSet.value != updatedValue,
-                "Does not update Beacon set"
-            );
-        }
+        require(
+            updatedTimestamp > beaconSet.timestamp,
+            "Does not update timestamp"
+        );
+        require(updatedValue != beaconSet.value, "Does not update value");
         _dataFeeds[beaconSetId] = DataFeed({
             value: updatedValue,
             timestamp: updatedTimestamp

--- a/test/dapis/Api3ServerV1.sol.js
+++ b/test/dapis/Api3ServerV1.sol.js
@@ -221,37 +221,37 @@ describe('Api3ServerV1', function () {
 
   describe('updateBeaconSetWithBeacons', function () {
     context('Did not specify less than two Beacons', function () {
-      context('Beacons update Beacon set timestamp', function () {
-        it('updates Beacon set', async function () {
-          const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
-          // Populate the Beacons
-          const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
-          const currentTimestamp = await helpers.time.latest();
-          const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
-          await Promise.all(
-            beacons.map(async (beacon, index) => {
-              await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
-            })
-          );
-          const beaconSetValue = median(beaconValues);
-          const beaconSetTimestamp = median(beaconTimestamps);
-          const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-          expect(beaconSetBefore.value).to.equal(0);
-          expect(beaconSetBefore.timestamp).to.equal(0);
-          expect(
-            await api3ServerV1.connect(roles.randomPerson).callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
-          ).to.equal(beaconSet.beaconSetId);
-          await expect(api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
-            .to.emit(api3ServerV1, 'UpdatedBeaconSetWithBeacons')
-            .withArgs(beaconSet.beaconSetId, beaconSetValue, beaconSetTimestamp);
-          const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-          expect(beaconSetAfter.value).to.equal(beaconSetValue);
-          expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
-        });
-      });
-      context('Beacons do not update Beacon set timestamp', function () {
-        context('Beacons update Beacon set value', function () {
+      context('Updates timestamp', function () {
+        context('Updates value', function () {
           it('updates Beacon set', async function () {
+            const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
+            // Populate the Beacons
+            const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
+            const currentTimestamp = await helpers.time.latest();
+            const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
+            await Promise.all(
+              beacons.map(async (beacon, index) => {
+                await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
+              })
+            );
+            const beaconSetValue = median(beaconValues);
+            const beaconSetTimestamp = median(beaconTimestamps);
+            const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetBefore.value).to.equal(0);
+            expect(beaconSetBefore.timestamp).to.equal(0);
+            expect(
+              await api3ServerV1.connect(roles.randomPerson).callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
+            ).to.equal(beaconSet.beaconSetId);
+            await expect(api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
+              .to.emit(api3ServerV1, 'UpdatedBeaconSetWithBeacons')
+              .withArgs(beaconSet.beaconSetId, beaconSetValue, beaconSetTimestamp);
+            const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetAfter.value).to.equal(beaconSetValue);
+            expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
+          });
+        });
+        context('Does not update value', function () {
+          it('reverts', async function () {
             const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
             // Populate the Beacons
             const beaconValues = [100, 80, 120];
@@ -262,34 +262,36 @@ describe('Api3ServerV1', function () {
                 await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
               })
             );
-            const beaconIds = beacons.map((beacon) => {
-              return beacon.beaconId;
-            });
-            await api3ServerV1.updateBeaconSetWithBeacons(beaconIds);
-            await updateBeacon(roles, api3ServerV1, beacons[0], 110, currentTimestamp + 10);
-            const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetBefore.value).to.equal(100);
-            expect(beaconSetBefore.timestamp).to.equal(currentTimestamp);
-            expect(
-              await api3ServerV1.connect(roles.randomPerson).callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.equal(beaconSet.beaconSetId);
-            await expect(api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
-              .to.emit(api3ServerV1, 'UpdatedBeaconSetWithBeacons')
-              .withArgs(beaconSet.beaconSetId, 110, currentTimestamp);
-            const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetAfter.value).to.equal(110);
-            expect(beaconSetAfter.timestamp).to.equal(currentTimestamp);
-          });
-        });
-        context('Beacons do not update Beacon set value', function () {
-          it('reverts', async function () {
-            const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
-            // Update Beacon set with recent timestamp
-            await updateBeaconSet(roles, api3ServerV1, beacons, 123);
+            // Update the Beacon set
+            await api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
+            // Update the Beacons in a way that it will not affect the aggregated value
+            await updateBeacon(roles, api3ServerV1, beacons[1], 79, currentTimestamp + 1);
+            await updateBeacon(roles, api3ServerV1, beacons[2], 121, currentTimestamp + 1);
             await expect(
               api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.be.revertedWith('Does not update Beacon set');
+            ).to.be.revertedWith('Does not update value');
           });
+        });
+      });
+      context('Does not update timestamp', function () {
+        it('reverts', async function () {
+          const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
+          // Populate the Beacons
+          const beaconValues = [100, 80, 120];
+          const currentTimestamp = await helpers.time.latest();
+          const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
+          await Promise.all(
+            beacons.map(async (beacon, index) => {
+              await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
+            })
+          );
+          // Update the Beacon set
+          await api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
+          // Update the Beacons in a way that it will not affect the aggregated timestamp
+          await updateBeacon(roles, api3ServerV1, beacons[0], 101, currentTimestamp + 1);
+          await expect(
+            api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
+          ).to.be.revertedWith('Does not update timestamp');
         });
       });
     });

--- a/test/dapis/Api3ServerV1.sol.js
+++ b/test/dapis/Api3ServerV1.sol.js
@@ -313,7 +313,7 @@ describe('Api3ServerV1', function () {
       context('Signature is valid', function () {
         context('Fulfillment data length is correct', function () {
           context('Decoded fulfillment data can be typecasted into int224', function () {
-            context('Updates timestamp', function () {
+            context('Updates timestamp from a non-zero value', function () {
               context('Updates value', function () {
                 it('updates Beacon with signed data', async function () {
                   const { roles, api3ServerV1, beacons } = await deploy();
@@ -387,6 +387,39 @@ describe('Api3ServerV1', function () {
                       )
                   ).to.be.revertedWith('Does not update value');
                 });
+              });
+            });
+            context('Updates timestamp from a zero value', function () {
+              it('updates Beacon with signed data', async function () {
+                const { roles, api3ServerV1, beacons } = await deploy();
+                const beacon = beacons[0];
+                const beaconValue = 0;
+                const beaconTimestamp = await helpers.time.latest();
+                const signature = await testUtils.signData(
+                  beacon.airnode.wallet,
+                  beacon.templateId,
+                  beaconTimestamp,
+                  encodeData(beaconValue)
+                );
+                const beaconBefore = await api3ServerV1.dataFeeds(beacon.beaconId);
+                expect(beaconBefore.value).to.equal(0);
+                expect(beaconBefore.timestamp).to.equal(0);
+                await expect(
+                  api3ServerV1
+                    .connect(roles.randomPerson)
+                    .updateBeaconWithSignedData(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beaconTimestamp,
+                      encodeData(beaconValue),
+                      signature
+                    )
+                )
+                  .to.emit(api3ServerV1, 'UpdatedBeaconWithSignedData')
+                  .withArgs(beacon.beaconId, beaconValue, beaconTimestamp);
+                const beaconAfter = await api3ServerV1.dataFeeds(beacon.beaconId);
+                expect(beaconAfter.value).to.equal(beaconValue);
+                expect(beaconAfter.timestamp).to.equal(beaconTimestamp);
               });
             });
             context('Does not update timestamp', function () {

--- a/test/dapis/DataFeedServerFull.sol.js
+++ b/test/dapis/DataFeedServerFull.sol.js
@@ -2542,39 +2542,39 @@ describe('DataFeedServerFull', function () {
 
   describe('updateBeaconSetWithBeacons', function () {
     context('Did not specify less than two Beacons', function () {
-      context('Beacons update Beacon set timestamp', function () {
-        it('updates Beacon set', async function () {
-          const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
-          // Populate the Beacons
-          const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
-          const currentTimestamp = await helpers.time.latest();
-          const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
-          await Promise.all(
-            beacons.map(async (beacon, index) => {
-              await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
-            })
-          );
-          const beaconSetValue = median(beaconValues);
-          const beaconSetTimestamp = median(beaconTimestamps);
-          const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-          expect(beaconSetBefore.value).to.equal(0);
-          expect(beaconSetBefore.timestamp).to.equal(0);
-          expect(
-            await dataFeedServerFull
-              .connect(roles.randomPerson)
-              .callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
-          ).to.equal(beaconSet.beaconSetId);
-          await expect(dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
-            .to.emit(dataFeedServerFull, 'UpdatedBeaconSetWithBeacons')
-            .withArgs(beaconSet.beaconSetId, beaconSetValue, beaconSetTimestamp);
-          const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-          expect(beaconSetAfter.value).to.equal(beaconSetValue);
-          expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
-        });
-      });
-      context('Beacons do not update Beacon set timestamp', function () {
-        context('Beacons update Beacon set value', function () {
+      context('Updates timestamp', function () {
+        context('Updates value', function () {
           it('updates Beacon set', async function () {
+            const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
+            // Populate the Beacons
+            const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
+            const currentTimestamp = await helpers.time.latest();
+            const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
+            await Promise.all(
+              beacons.map(async (beacon, index) => {
+                await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
+              })
+            );
+            const beaconSetValue = median(beaconValues);
+            const beaconSetTimestamp = median(beaconTimestamps);
+            const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetBefore.value).to.equal(0);
+            expect(beaconSetBefore.timestamp).to.equal(0);
+            expect(
+              await dataFeedServerFull
+                .connect(roles.randomPerson)
+                .callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
+            ).to.equal(beaconSet.beaconSetId);
+            await expect(dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
+              .to.emit(dataFeedServerFull, 'UpdatedBeaconSetWithBeacons')
+              .withArgs(beaconSet.beaconSetId, beaconSetValue, beaconSetTimestamp);
+            const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetAfter.value).to.equal(beaconSetValue);
+            expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
+          });
+        });
+        context('Does not update value', function () {
+          it('reverts', async function () {
             const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
             // Populate the Beacons
             const beaconValues = [100, 80, 120];
@@ -2585,36 +2585,36 @@ describe('DataFeedServerFull', function () {
                 await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
               })
             );
-            const beaconIds = beacons.map((beacon) => {
-              return beacon.beaconId;
-            });
-            await dataFeedServerFull.updateBeaconSetWithBeacons(beaconIds);
-            await updateBeacon(roles, dataFeedServerFull, beacons[0], 110, currentTimestamp + 10);
-            const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetBefore.value).to.equal(100);
-            expect(beaconSetBefore.timestamp).to.equal(currentTimestamp);
-            expect(
-              await dataFeedServerFull
-                .connect(roles.randomPerson)
-                .callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.equal(beaconSet.beaconSetId);
-            await expect(dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
-              .to.emit(dataFeedServerFull, 'UpdatedBeaconSetWithBeacons')
-              .withArgs(beaconSet.beaconSetId, 110, currentTimestamp);
-            const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetAfter.value).to.equal(110);
-            expect(beaconSetAfter.timestamp).to.equal(currentTimestamp);
-          });
-        });
-        context('Beacons do not update Beacon set value', function () {
-          it('reverts', async function () {
-            const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
-            // Update Beacon set with recent timestamp
-            await updateBeaconSet(roles, dataFeedServerFull, beacons, 123);
+            // Update the Beacon set
+            await dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
+            // Update the Beacons in a way that it will not affect the aggregated value
+            await updateBeacon(roles, dataFeedServerFull, beacons[1], 79, currentTimestamp + 1);
+            await updateBeacon(roles, dataFeedServerFull, beacons[2], 121, currentTimestamp + 1);
             await expect(
               dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.be.revertedWith('Does not update Beacon set');
+            ).to.be.revertedWith('Does not update value');
           });
+        });
+      });
+      context('Does not update timestamp', function () {
+        it('reverts', async function () {
+          const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
+          // Populate the Beacons
+          const beaconValues = [100, 80, 120];
+          const currentTimestamp = await helpers.time.latest();
+          const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
+          await Promise.all(
+            beacons.map(async (beacon, index) => {
+              await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
+            })
+          );
+          // Update the Beacon set
+          await dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
+          // Update the Beacons in a way that it will not affect the aggregated timestamp
+          await updateBeacon(roles, dataFeedServerFull, beacons[0], 101, currentTimestamp + 1);
+          await expect(
+            dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
+          ).to.be.revertedWith('Does not update timestamp');
         });
       });
     });

--- a/test/dapis/DataFeedServerFull.sol.js
+++ b/test/dapis/DataFeedServerFull.sol.js
@@ -58,6 +58,49 @@ describe('DataFeedServerFull', function () {
     ];
     await dataFeedServerFull.connect(roles.randomPerson).multicall(updateBeaconSetCalldata);
   }
+  async function updateProxyDataFeed(
+    roles,
+    dataFeedServerFull,
+    oevProxyAddress,
+    beacons,
+    updateId,
+    dataFeedId,
+    decodedData,
+    timestamp
+  ) {
+    if (!timestamp) {
+      timestamp = await helpers.time.latest();
+    }
+    const data = encodeData(decodedData);
+    const packedOevUpdateSignatures = await Promise.all(
+      beacons.map(async (beacon) => {
+        const signature = await testUtils.signOevData(
+          dataFeedServerFull,
+          oevProxyAddress,
+          dataFeedId,
+          updateId,
+          timestamp,
+          data,
+          roles.searcher.address,
+          1,
+          beacon.airnode.wallet,
+          beacon.templateId
+        );
+        return packOevUpdateSignature(beacon.airnode.wallet.address, beacon.templateId, signature);
+      })
+    );
+    await dataFeedServerFull
+      .connect(roles.searcher)
+      .updateOevProxyDataFeedWithSignedData(
+        oevProxyAddress,
+        dataFeedId,
+        updateId,
+        timestamp,
+        data,
+        packedOevUpdateSignatures,
+        { value: 1 }
+      );
+  }
 
   function encodeUpdateSubscriptionConditionParameters(
     deviationThresholdInPercentage,
@@ -3386,15 +3429,242 @@ describe('DataFeedServerFull', function () {
 
   describe('updateOevProxyDataFeedWithSignedData', function () {
     context('Timestamp is valid', function () {
-      context('Updates timestamp', function () {
-        context('Fulfillment data length is correct', function () {
-          context('Decoded fulfillment data can be typecasted into int224', function () {
-            context('More than one Beacon is specified', function () {
-              context('There are no invalid signatures', function () {
-                context('There are enough signatures to constitute an absolute majority', function () {
-                  context('Data in packed signatures is consistent with the data feed ID', function () {
-                    it('updates OEV proxy Beacon set with signed data', async function () {
+      context('Fulfillment data length is correct', function () {
+        context('Decoded fulfillment data can be typecasted into int224', function () {
+          context('Updates timestamp from a non-zero value', function () {
+            context('Updates value', function () {
+              context('Updated value not same as base feed value', function () {
+                context('More than one Beacon is specified', function () {
+                  context('There are no invalid signatures', function () {
+                    context('There are enough signatures to constitute an absolute majority', function () {
+                      context('Data in packed signatures is consistent with the data feed ID', function () {
+                        it('updates OEV proxy Beacon set with signed data', async function () {
+                          const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
+                          await updateProxyDataFeed(
+                            roles,
+                            dataFeedServerFull,
+                            oevProxy.address,
+                            beacons,
+                            testUtils.generateRandomBytes32(),
+                            beaconSet.beaconSetId,
+                            1,
+                            1
+                          );
+                          const oevUpdateValue = 105;
+                          const currentTimestamp = await helpers.time.latest();
+                          const oevUpdateTimestamp = currentTimestamp + 1;
+                          const bidAmount = 10000;
+                          const updateId = testUtils.generateRandomBytes32();
+                          // Randomly omit one of the signatures
+                          const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                          const signatures = await Promise.all(
+                            beacons.map(async (beacon, index) => {
+                              if (index === omitSignatureAtIndex) {
+                                return '0x';
+                              } else {
+                                return await testUtils.signOevData(
+                                  dataFeedServerFull,
+                                  oevProxy.address,
+                                  beaconSet.beaconSetId,
+                                  updateId,
+                                  oevUpdateTimestamp,
+                                  encodeData(oevUpdateValue),
+                                  roles.searcher.address,
+                                  bidAmount,
+                                  beacon.airnode.wallet,
+                                  beacon.templateId
+                                );
+                              }
+                            })
+                          );
+                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                            return packOevUpdateSignature(
+                              beacons[index].airnode.wallet.address,
+                              beacons[index].templateId,
+                              signature
+                            );
+                          });
+                          const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+                          expect(beaconSetBefore.value).to.equal(0);
+                          expect(beaconSetBefore.timestamp).to.equal(0);
+                          const oevProxyBeaconSetBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                            oevProxy.address,
+                            beaconSet.beaconSetId
+                          );
+                          expect(oevProxyBeaconSetBefore.value).to.equal(1);
+                          expect(oevProxyBeaconSetBefore.timestamp).to.equal(1);
+                          await expect(
+                            dataFeedServerFull
+                              .connect(roles.searcher)
+                              .updateOevProxyDataFeedWithSignedData(
+                                oevProxy.address,
+                                beaconSet.beaconSetId,
+                                updateId,
+                                oevUpdateTimestamp,
+                                encodeData(oevUpdateValue),
+                                packedOevUpdateSignatures,
+                                { value: bidAmount }
+                              )
+                          )
+                            .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconSetWithSignedData')
+                            .withArgs(
+                              beaconSet.beaconSetId,
+                              oevProxy.address,
+                              updateId,
+                              oevUpdateValue,
+                              oevUpdateTimestamp
+                            );
+                          const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+                          expect(beaconSetAfter.value).to.equal(0);
+                          expect(beaconSetAfter.timestamp).to.equal(0);
+                          const oevProxyBeaconSetAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                            oevProxy.address,
+                            beaconSet.beaconSetId
+                          );
+                          expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
+                          expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
+                        });
+                      });
+                      context('Data in packed signatures is not consistent with the data feed ID', function () {
+                        it('reverts', async function () {
+                          const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
+                          await updateProxyDataFeed(
+                            roles,
+                            dataFeedServerFull,
+                            oevProxy.address,
+                            beacons,
+                            testUtils.generateRandomBytes32(),
+                            beaconSet.beaconSetId,
+                            1,
+                            1
+                          );
+                          const oevUpdateValue = 105;
+                          const currentTimestamp = await helpers.time.latest();
+                          const oevUpdateTimestamp = currentTimestamp + 1;
+                          const bidAmount = 10000;
+                          const updateId = testUtils.generateRandomBytes32();
+                          // Randomly omit one of the signatures
+                          const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                          const spoofedDataFeedId = testUtils.generateRandomBytes32();
+                          const signatures = await Promise.all(
+                            beacons.map(async (beacon, index) => {
+                              if (index === omitSignatureAtIndex) {
+                                return '0x';
+                              } else {
+                                return await testUtils.signOevData(
+                                  dataFeedServerFull,
+                                  oevProxy.address,
+                                  spoofedDataFeedId,
+                                  updateId,
+                                  oevUpdateTimestamp,
+                                  encodeData(oevUpdateValue),
+                                  roles.searcher.address,
+                                  bidAmount,
+                                  beacon.airnode.wallet,
+                                  beacon.templateId
+                                );
+                              }
+                            })
+                          );
+                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                            return packOevUpdateSignature(
+                              beacons[index].airnode.wallet.address,
+                              beacons[index].templateId,
+                              signature
+                            );
+                          });
+                          await expect(
+                            dataFeedServerFull
+                              .connect(roles.searcher)
+                              .updateOevProxyDataFeedWithSignedData(
+                                oevProxy.address,
+                                spoofedDataFeedId,
+                                updateId,
+                                oevUpdateTimestamp,
+                                encodeData(oevUpdateValue),
+                                packedOevUpdateSignatures,
+                                { value: bidAmount }
+                              )
+                          ).to.be.revertedWith('Beacon set ID mismatch');
+                        });
+                      });
+                    });
+                    context('There are not enough signatures to constitute an absolute majority', function () {
+                      it('reverts', async function () {
+                        const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
+                        await updateProxyDataFeed(
+                          roles,
+                          dataFeedServerFull,
+                          oevProxy.address,
+                          beacons,
+                          testUtils.generateRandomBytes32(),
+                          beaconSet.beaconSetId,
+                          1,
+                          1
+                        );
+                        const oevUpdateValue = 105;
+                        const currentTimestamp = await helpers.time.latest();
+                        const oevUpdateTimestamp = currentTimestamp + 1;
+                        const bidAmount = 10000;
+                        const updateId = testUtils.generateRandomBytes32();
+                        // Randomly omit two of the signatures
+                        const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                        const signatures = await Promise.all(
+                          beacons.map(async (beacon, index) => {
+                            if (index !== includeSignatureAtIndex) {
+                              return '0x';
+                            } else {
+                              return await testUtils.signOevData(
+                                dataFeedServerFull,
+                                oevProxy.address,
+                                beaconSet.beaconSetId,
+                                updateId,
+                                oevUpdateTimestamp,
+                                encodeData(oevUpdateValue),
+                                roles.searcher.address,
+                                bidAmount,
+                                beacon.airnode.wallet,
+                                beacon.templateId
+                              );
+                            }
+                          })
+                        );
+                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                          return packOevUpdateSignature(
+                            beacons[index].airnode.wallet.address,
+                            beacons[index].templateId,
+                            signature
+                          );
+                        });
+                        await expect(
+                          dataFeedServerFull
+                            .connect(roles.searcher)
+                            .updateOevProxyDataFeedWithSignedData(
+                              oevProxy.address,
+                              beaconSet.beaconSetId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              packedOevUpdateSignatures,
+                              { value: bidAmount }
+                            )
+                        ).to.be.revertedWith('Not enough signatures');
+                      });
+                    });
+                  });
+                  context('There are invalid signatures', function () {
+                    it('reverts', async function () {
                       const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
+                      await updateProxyDataFeed(
+                        roles,
+                        dataFeedServerFull,
+                        oevProxy.address,
+                        beacons,
+                        testUtils.generateRandomBytes32(),
+                        beaconSet.beaconSetId,
+                        1,
+                        1
+                      );
                       const oevUpdateValue = 105;
                       const currentTimestamp = await helpers.time.latest();
                       const oevUpdateTimestamp = currentTimestamp + 1;
@@ -3405,6 +3675,531 @@ describe('DataFeedServerFull', function () {
                       const signatures = await Promise.all(
                         beacons.map(async (beacon, index) => {
                           if (index === omitSignatureAtIndex) {
+                            return '0x';
+                          } else {
+                            return '0x123456';
+                          }
+                        })
+                      );
+                      const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                        return packOevUpdateSignature(
+                          beacons[index].airnode.wallet.address,
+                          beacons[index].templateId,
+                          signature
+                        );
+                      });
+                      await expect(
+                        dataFeedServerFull
+                          .connect(roles.searcher)
+                          .updateOevProxyDataFeedWithSignedData(
+                            oevProxy.address,
+                            beaconSet.beaconSetId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            packedOevUpdateSignatures,
+                            { value: bidAmount }
+                          )
+                      ).to.be.revertedWith('ECDSA: invalid signature length');
+                    });
+                  });
+                });
+                context('One Beacon is specified', function () {
+                  context('The signature is not invalid', function () {
+                    context('The signature is not omitted', function () {
+                      context('Data in the packed signature is consistent with the data feed ID', function () {
+                        it('updates OEV proxy Beacon with signed data', async function () {
+                          const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                          const beacon = beacons[0];
+                          await updateProxyDataFeed(
+                            roles,
+                            dataFeedServerFull,
+                            oevProxy.address,
+                            [beacon],
+                            testUtils.generateRandomBytes32(),
+                            beacon.beaconId,
+                            1,
+                            1
+                          );
+                          const oevUpdateValue = 105;
+                          const currentTimestamp = await helpers.time.latest();
+                          const oevUpdateTimestamp = currentTimestamp + 1;
+                          const bidAmount = 10000;
+                          const updateId = testUtils.generateRandomBytes32();
+                          const signature = await testUtils.signOevData(
+                            dataFeedServerFull,
+                            oevProxy.address,
+                            beacon.beaconId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            roles.searcher.address,
+                            bidAmount,
+                            beacon.airnode.wallet,
+                            beacon.templateId
+                          );
+                          const packedOevUpdateSignature = packOevUpdateSignature(
+                            beacon.airnode.wallet.address,
+                            beacon.templateId,
+                            signature
+                          );
+                          const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                          expect(beaconBefore.value).to.equal(0);
+                          expect(beaconBefore.timestamp).to.equal(0);
+                          const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                            oevProxy.address,
+                            beacon.beaconId
+                          );
+                          expect(oevProxyBeaconBefore.value).to.equal(1);
+                          expect(oevProxyBeaconBefore.timestamp).to.equal(1);
+                          await expect(
+                            dataFeedServerFull
+                              .connect(roles.searcher)
+                              .updateOevProxyDataFeedWithSignedData(
+                                oevProxy.address,
+                                beacon.beaconId,
+                                updateId,
+                                oevUpdateTimestamp,
+                                encodeData(oevUpdateValue),
+                                [packedOevUpdateSignature],
+                                { value: bidAmount }
+                              )
+                          )
+                            .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconWithSignedData')
+                            .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
+                          const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                          expect(beaconAfter.value).to.equal(0);
+                          expect(beaconAfter.timestamp).to.equal(0);
+                          const oevProxyBeaconAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                            oevProxy.address,
+                            beacon.beaconId
+                          );
+                          expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
+                          expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
+                        });
+                      });
+                      context('Data in the packed signature is not consistent with the data feed ID', function () {
+                        it('reverts', async function () {
+                          const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                          const beacon = beacons[0];
+                          await updateProxyDataFeed(
+                            roles,
+                            dataFeedServerFull,
+                            oevProxy.address,
+                            [beacon],
+                            testUtils.generateRandomBytes32(),
+                            beacon.beaconId,
+                            1,
+                            1
+                          );
+                          const oevUpdateValue = 105;
+                          const currentTimestamp = await helpers.time.latest();
+                          const oevUpdateTimestamp = currentTimestamp + 1;
+                          const bidAmount = 10000;
+                          const updateId = testUtils.generateRandomBytes32();
+                          const spoofedDataFeedId = testUtils.generateRandomBytes32();
+                          const signature = await testUtils.signOevData(
+                            dataFeedServerFull,
+                            oevProxy.address,
+                            spoofedDataFeedId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            roles.searcher.address,
+                            bidAmount,
+                            beacon.airnode.wallet,
+                            beacon.templateId
+                          );
+                          const packedOevUpdateSignature = packOevUpdateSignature(
+                            beacon.airnode.wallet.address,
+                            beacon.templateId,
+                            signature
+                          );
+                          await expect(
+                            dataFeedServerFull
+                              .connect(roles.searcher)
+                              .updateOevProxyDataFeedWithSignedData(
+                                oevProxy.address,
+                                spoofedDataFeedId,
+                                updateId,
+                                oevUpdateTimestamp,
+                                encodeData(oevUpdateValue),
+                                [packedOevUpdateSignature],
+                                { value: bidAmount }
+                              )
+                          ).to.be.revertedWith('Beacon ID mismatch');
+                        });
+                      });
+                    });
+                    context('The signature is omitted', function () {
+                      it('reverts', async function () {
+                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                        const beacon = beacons[0];
+                        await updateProxyDataFeed(
+                          roles,
+                          dataFeedServerFull,
+                          oevProxy.address,
+                          [beacon],
+                          testUtils.generateRandomBytes32(),
+                          beacon.beaconId,
+                          1,
+                          1
+                        );
+                        const oevUpdateValue = 105;
+                        const currentTimestamp = await helpers.time.latest();
+                        const oevUpdateTimestamp = currentTimestamp + 1;
+                        const bidAmount = 10000;
+                        const updateId = testUtils.generateRandomBytes32();
+                        const packedOevUpdateSignature = packOevUpdateSignature(
+                          beacon.airnode.wallet.address,
+                          beacon.templateId,
+                          '0x'
+                        );
+                        await expect(
+                          dataFeedServerFull
+                            .connect(roles.searcher)
+                            .updateOevProxyDataFeedWithSignedData(
+                              oevProxy.address,
+                              beacon.beaconId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              [packedOevUpdateSignature],
+                              { value: bidAmount }
+                            )
+                        ).to.be.revertedWith('Missing signature');
+                      });
+                    });
+                  });
+                  context('The signature is invalid', function () {
+                    it('reverts', async function () {
+                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                      const beacon = beacons[0];
+                      await updateProxyDataFeed(
+                        roles,
+                        dataFeedServerFull,
+                        oevProxy.address,
+                        [beacon],
+                        testUtils.generateRandomBytes32(),
+                        beacon.beaconId,
+                        1,
+                        1
+                      );
+                      const oevUpdateValue = 105;
+                      const currentTimestamp = await helpers.time.latest();
+                      const oevUpdateTimestamp = currentTimestamp + 1;
+                      const bidAmount = 10000;
+                      const updateId = testUtils.generateRandomBytes32();
+                      const packedOevUpdateSignature = packOevUpdateSignature(
+                        beacon.airnode.wallet.address,
+                        beacon.templateId,
+                        '0x123456'
+                      );
+                      await expect(
+                        dataFeedServerFull
+                          .connect(roles.searcher)
+                          .updateOevProxyDataFeedWithSignedData(
+                            oevProxy.address,
+                            beacon.beaconId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            [packedOevUpdateSignature],
+                            { value: bidAmount }
+                          )
+                      ).to.be.revertedWith('ECDSA: invalid signature length');
+                    });
+                  });
+                });
+                context('No Beacon is specified', function () {
+                  it('reverts', async function () {
+                    const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                    const beacon = beacons[0];
+                    await updateProxyDataFeed(
+                      roles,
+                      dataFeedServerFull,
+                      oevProxy.address,
+                      [beacon],
+                      testUtils.generateRandomBytes32(),
+                      beacon.beaconId,
+                      1,
+                      1
+                    );
+                    const oevUpdateValue = 105;
+                    const currentTimestamp = await helpers.time.latest();
+                    const oevUpdateTimestamp = currentTimestamp + 1;
+                    const bidAmount = 10000;
+                    const updateId = testUtils.generateRandomBytes32();
+                    await expect(
+                      dataFeedServerFull
+                        .connect(roles.searcher)
+                        .updateOevProxyDataFeedWithSignedData(
+                          oevProxy.address,
+                          beacon.beaconId,
+                          updateId,
+                          oevUpdateTimestamp,
+                          encodeData(oevUpdateValue),
+                          [],
+                          { value: bidAmount }
+                        )
+                    ).to.be.revertedWith('Did not specify any Beacons');
+                  });
+                });
+              });
+              context('Updated value same as base feed value', function () {
+                it('reverts', async function () {
+                  const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                  const beacon = beacons[0];
+                  const oevUpdateValue = 105;
+                  await updateBeacon(roles, dataFeedServerFull, beacon, oevUpdateValue, 1);
+                  const updateId = testUtils.generateRandomBytes32();
+                  const currentTimestamp = await helpers.time.latest();
+                  const oevUpdateTimestamp = currentTimestamp + 1;
+                  const bidAmount = 10000;
+                  const signature = await testUtils.signOevData(
+                    dataFeedServerFull,
+                    oevProxy.address,
+                    beacon.beaconId,
+                    updateId,
+                    oevUpdateTimestamp,
+                    encodeData(oevUpdateValue),
+                    roles.searcher.address,
+                    bidAmount,
+                    beacon.airnode.wallet,
+                    beacon.templateId
+                  );
+                  const packedOevUpdateSignature = packOevUpdateSignature(
+                    beacon.airnode.wallet.address,
+                    beacon.templateId,
+                    signature
+                  );
+                  await expect(
+                    dataFeedServerFull
+                      .connect(roles.searcher)
+                      .updateOevProxyDataFeedWithSignedData(
+                        oevProxy.address,
+                        beacon.beaconId,
+                        updateId,
+                        oevUpdateTimestamp,
+                        encodeData(oevUpdateValue),
+                        [packedOevUpdateSignature],
+                        { value: bidAmount }
+                      )
+                  ).to.be.revertedWith('Updated value same as base feed');
+                });
+              });
+            });
+            context('Does not update value', function () {
+              it('reverts', async function () {
+                const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                const beacon = beacons[0];
+                const oevUpdateValue = 105;
+                await updateProxyDataFeed(
+                  roles,
+                  dataFeedServerFull,
+                  oevProxy.address,
+                  [beacon],
+                  testUtils.generateRandomBytes32(),
+                  beacon.beaconId,
+                  oevUpdateValue,
+                  1
+                );
+                const updateId = testUtils.generateRandomBytes32();
+                const currentTimestamp = await helpers.time.latest();
+                const oevUpdateTimestamp = currentTimestamp + 1;
+                const bidAmount = 10000;
+                const signature = await testUtils.signOevData(
+                  dataFeedServerFull,
+                  oevProxy.address,
+                  beacon.beaconId,
+                  updateId,
+                  oevUpdateTimestamp,
+                  encodeData(oevUpdateValue),
+                  roles.searcher.address,
+                  bidAmount,
+                  beacon.airnode.wallet,
+                  beacon.templateId
+                );
+                const packedOevUpdateSignature = packOevUpdateSignature(
+                  beacon.airnode.wallet.address,
+                  beacon.templateId,
+                  signature
+                );
+                await expect(
+                  dataFeedServerFull
+                    .connect(roles.searcher)
+                    .updateOevProxyDataFeedWithSignedData(
+                      oevProxy.address,
+                      beacon.beaconId,
+                      updateId,
+                      oevUpdateTimestamp,
+                      encodeData(oevUpdateValue),
+                      [packedOevUpdateSignature],
+                      { value: bidAmount }
+                    )
+                ).to.be.revertedWith('Does not update value');
+              });
+            });
+          });
+          context('Updates timestamp from zero', function () {
+            context('Updated value not same as base feed value', function () {
+              context('More than one Beacon is specified', function () {
+                context('There are no invalid signatures', function () {
+                  context('There are enough signatures to constitute an absolute majority', function () {
+                    context('Data in packed signatures is consistent with the data feed ID', function () {
+                      it('updates OEV proxy Beacon set with signed data', async function () {
+                        const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
+                        await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
+                        const oevUpdateValue = 0;
+                        const currentTimestamp = await helpers.time.latest();
+                        const oevUpdateTimestamp = currentTimestamp + 1;
+                        const bidAmount = 10000;
+                        const updateId = testUtils.generateRandomBytes32();
+                        // Randomly omit one of the signatures
+                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                        const signatures = await Promise.all(
+                          beacons.map(async (beacon, index) => {
+                            if (index === omitSignatureAtIndex) {
+                              return '0x';
+                            } else {
+                              return await testUtils.signOevData(
+                                dataFeedServerFull,
+                                oevProxy.address,
+                                beaconSet.beaconSetId,
+                                updateId,
+                                oevUpdateTimestamp,
+                                encodeData(oevUpdateValue),
+                                roles.searcher.address,
+                                bidAmount,
+                                beacon.airnode.wallet,
+                                beacon.templateId
+                              );
+                            }
+                          })
+                        );
+                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                          return packOevUpdateSignature(
+                            beacons[index].airnode.wallet.address,
+                            beacons[index].templateId,
+                            signature
+                          );
+                        });
+                        const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+                        expect(beaconSetBefore.value).to.equal(1);
+                        expect(beaconSetBefore.timestamp).to.equal(1);
+                        const oevProxyBeaconSetBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                          oevProxy.address,
+                          beaconSet.beaconSetId
+                        );
+                        expect(oevProxyBeaconSetBefore.value).to.equal(0);
+                        expect(oevProxyBeaconSetBefore.timestamp).to.equal(0);
+                        await expect(
+                          dataFeedServerFull
+                            .connect(roles.searcher)
+                            .updateOevProxyDataFeedWithSignedData(
+                              oevProxy.address,
+                              beaconSet.beaconSetId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              packedOevUpdateSignatures,
+                              { value: bidAmount }
+                            )
+                        )
+                          .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconSetWithSignedData')
+                          .withArgs(
+                            beaconSet.beaconSetId,
+                            oevProxy.address,
+                            updateId,
+                            oevUpdateValue,
+                            oevUpdateTimestamp
+                          );
+                        const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+                        expect(beaconSetAfter.value).to.equal(1);
+                        expect(beaconSetAfter.timestamp).to.equal(1);
+                        const oevProxyBeaconSetAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                          oevProxy.address,
+                          beaconSet.beaconSetId
+                        );
+                        expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
+                        expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
+                      });
+                    });
+                    context('Data in packed signatures is not consistent with the data feed ID', function () {
+                      it('reverts', async function () {
+                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                        const spoofedDataFeedId = ethers.utils.keccak256(
+                          ethers.utils.defaultAbiCoder.encode(
+                            ['bytes32[]'],
+                            [[beacons[0].beaconId, beacons[1].beaconId]]
+                          )
+                        );
+                        await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
+                        await dataFeedServerFull.updateBeaconSetWithBeacons([beacons[0].beaconId, beacons[1].beaconId]);
+                        const oevUpdateValue = 0;
+                        const currentTimestamp = await helpers.time.latest();
+                        const oevUpdateTimestamp = currentTimestamp + 1;
+                        const bidAmount = 10000;
+                        const updateId = testUtils.generateRandomBytes32();
+                        // Randomly omit one of the signatures
+                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                        const signatures = await Promise.all(
+                          beacons.map(async (beacon, index) => {
+                            if (index === omitSignatureAtIndex) {
+                              return '0x';
+                            } else {
+                              return await testUtils.signOevData(
+                                dataFeedServerFull,
+                                oevProxy.address,
+                                spoofedDataFeedId,
+                                updateId,
+                                oevUpdateTimestamp,
+                                encodeData(oevUpdateValue),
+                                roles.searcher.address,
+                                bidAmount,
+                                beacon.airnode.wallet,
+                                beacon.templateId
+                              );
+                            }
+                          })
+                        );
+                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                          return packOevUpdateSignature(
+                            beacons[index].airnode.wallet.address,
+                            beacons[index].templateId,
+                            signature
+                          );
+                        });
+                        await expect(
+                          dataFeedServerFull
+                            .connect(roles.searcher)
+                            .updateOevProxyDataFeedWithSignedData(
+                              oevProxy.address,
+                              spoofedDataFeedId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              packedOevUpdateSignatures,
+                              { value: bidAmount }
+                            )
+                        ).to.be.revertedWith('Beacon set ID mismatch');
+                      });
+                    });
+                  });
+                  context('There are not enough signatures to constitute an absolute majority', function () {
+                    it('reverts', async function () {
+                      const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
+                      await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
+                      const oevUpdateValue = 0;
+                      const currentTimestamp = await helpers.time.latest();
+                      const oevUpdateTimestamp = currentTimestamp + 1;
+                      const bidAmount = 10000;
+                      const updateId = testUtils.generateRandomBytes32();
+                      // Randomly omit two of the signatures
+                      const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                      const signatures = await Promise.all(
+                        beacons.map(async (beacon, index) => {
+                          if (index !== includeSignatureAtIndex) {
                             return '0x';
                           } else {
                             return await testUtils.signOevData(
@@ -3429,15 +4224,6 @@ describe('DataFeedServerFull', function () {
                           signature
                         );
                       });
-                      const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                      expect(beaconSetBefore.value).to.equal(0);
-                      expect(beaconSetBefore.timestamp).to.equal(0);
-                      const oevProxyBeaconSetBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                        oevProxy.address,
-                        beaconSet.beaconSetId
-                      );
-                      expect(oevProxyBeaconSetBefore.value).to.equal(0);
-                      expect(oevProxyBeaconSetBefore.timestamp).to.equal(0);
                       await expect(
                         dataFeedServerFull
                           .connect(roles.searcher)
@@ -3450,107 +4236,27 @@ describe('DataFeedServerFull', function () {
                             packedOevUpdateSignatures,
                             { value: bidAmount }
                           )
-                      )
-                        .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconSetWithSignedData')
-                        .withArgs(
-                          beaconSet.beaconSetId,
-                          oevProxy.address,
-                          updateId,
-                          oevUpdateValue,
-                          oevUpdateTimestamp
-                        );
-                      const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                      expect(beaconSetAfter.value).to.equal(0);
-                      expect(beaconSetAfter.timestamp).to.equal(0);
-                      const oevProxyBeaconSetAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                        oevProxy.address,
-                        beaconSet.beaconSetId
-                      );
-                      expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
-                      expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
-                    });
-                  });
-                  context('Data in packed signatures is not consistent with the data feed ID', function () {
-                    it('reverts', async function () {
-                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                      const oevUpdateValue = 105;
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      // Randomly omit one of the signatures
-                      const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                      const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                      const signatures = await Promise.all(
-                        beacons.map(async (beacon, index) => {
-                          if (index === omitSignatureAtIndex) {
-                            return '0x';
-                          } else {
-                            return await testUtils.signOevData(
-                              dataFeedServerFull,
-                              oevProxy.address,
-                              spoofedDataFeedId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              roles.searcher.address,
-                              bidAmount,
-                              beacon.airnode.wallet,
-                              beacon.templateId
-                            );
-                          }
-                        })
-                      );
-                      const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                        return packOevUpdateSignature(
-                          beacons[index].airnode.wallet.address,
-                          beacons[index].templateId,
-                          signature
-                        );
-                      });
-                      await expect(
-                        dataFeedServerFull
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            spoofedDataFeedId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            packedOevUpdateSignatures,
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('Beacon set ID mismatch');
+                      ).to.be.revertedWith('Not enough signatures');
                     });
                   });
                 });
-                context('There are not enough signatures to constitute an absolute majority', function () {
+                context('There are invalid signatures', function () {
                   it('reverts', async function () {
                     const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                    const oevUpdateValue = 105;
+                    await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
+                    const oevUpdateValue = 0;
                     const currentTimestamp = await helpers.time.latest();
                     const oevUpdateTimestamp = currentTimestamp + 1;
                     const bidAmount = 10000;
                     const updateId = testUtils.generateRandomBytes32();
-                    // Randomly omit two of the signatures
-                    const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                    // Randomly omit one of the signatures
+                    const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
                     const signatures = await Promise.all(
                       beacons.map(async (beacon, index) => {
-                        if (index !== includeSignatureAtIndex) {
+                        if (index === omitSignatureAtIndex) {
                           return '0x';
                         } else {
-                          return await testUtils.signOevData(
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            beaconSet.beaconSetId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            roles.searcher.address,
-                            bidAmount,
-                            beacon.airnode.wallet,
-                            beacon.templateId
-                          );
+                          return '0x123456';
                         }
                       })
                     );
@@ -3573,90 +4279,135 @@ describe('DataFeedServerFull', function () {
                           packedOevUpdateSignatures,
                           { value: bidAmount }
                         )
-                    ).to.be.revertedWith('Not enough signatures');
+                    ).to.be.revertedWith('ECDSA: invalid signature length');
                   });
                 });
               });
-              context('There are invalid signatures', function () {
-                it('reverts', async function () {
-                  const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                  const oevUpdateValue = 105;
-                  const currentTimestamp = await helpers.time.latest();
-                  const oevUpdateTimestamp = currentTimestamp + 1;
-                  const bidAmount = 10000;
-                  const updateId = testUtils.generateRandomBytes32();
-                  // Randomly omit one of the signatures
-                  const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                  const signatures = await Promise.all(
-                    beacons.map(async (beacon, index) => {
-                      if (index === omitSignatureAtIndex) {
-                        return '0x';
-                      } else {
-                        return '0x123456';
-                      }
-                    })
-                  );
-                  const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                    return packOevUpdateSignature(
-                      beacons[index].airnode.wallet.address,
-                      beacons[index].templateId,
-                      signature
-                    );
+              context('One Beacon is specified', function () {
+                context('The signature is not invalid', function () {
+                  context('The signature is not omitted', function () {
+                    context('Data in the packed signature is consistent with the data feed ID', function () {
+                      it('updates OEV proxy Beacon with signed data', async function () {
+                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                        const beacon = beacons[0];
+                        await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
+                        const oevUpdateValue = 0;
+                        const currentTimestamp = await helpers.time.latest();
+                        const oevUpdateTimestamp = currentTimestamp + 1;
+                        const bidAmount = 10000;
+                        const updateId = testUtils.generateRandomBytes32();
+                        const signature = await testUtils.signOevData(
+                          dataFeedServerFull,
+                          oevProxy.address,
+                          beacon.beaconId,
+                          updateId,
+                          oevUpdateTimestamp,
+                          encodeData(oevUpdateValue),
+                          roles.searcher.address,
+                          bidAmount,
+                          beacon.airnode.wallet,
+                          beacon.templateId
+                        );
+                        const packedOevUpdateSignature = packOevUpdateSignature(
+                          beacon.airnode.wallet.address,
+                          beacon.templateId,
+                          signature
+                        );
+                        const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                        expect(beaconBefore.value).to.equal(1);
+                        expect(beaconBefore.timestamp).to.equal(1);
+                        const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                          oevProxy.address,
+                          beacon.beaconId
+                        );
+                        expect(oevProxyBeaconBefore.value).to.equal(0);
+                        expect(oevProxyBeaconBefore.timestamp).to.equal(0);
+                        await expect(
+                          dataFeedServerFull
+                            .connect(roles.searcher)
+                            .updateOevProxyDataFeedWithSignedData(
+                              oevProxy.address,
+                              beacon.beaconId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              [packedOevUpdateSignature],
+                              { value: bidAmount }
+                            )
+                        )
+                          .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconWithSignedData')
+                          .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
+                        const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                        expect(beaconAfter.value).to.equal(1);
+                        expect(beaconAfter.timestamp).to.equal(1);
+                        const oevProxyBeaconAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                          oevProxy.address,
+                          beacon.beaconId
+                        );
+                        expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
+                        expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
+                      });
+                    });
+                    context('Data in the packed signature is not consistent with the data feed ID', function () {
+                      it('reverts', async function () {
+                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                        const beacon = beacons[0];
+                        const spoofedDataFeedId = beacons[1].beaconId;
+                        await updateBeacon(roles, dataFeedServerFull, beacons[1], 1, 1);
+                        await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
+                        const oevUpdateValue = 0;
+                        const currentTimestamp = await helpers.time.latest();
+                        const oevUpdateTimestamp = currentTimestamp + 1;
+                        const bidAmount = 10000;
+                        const updateId = testUtils.generateRandomBytes32();
+                        const signature = await testUtils.signOevData(
+                          dataFeedServerFull,
+                          oevProxy.address,
+                          spoofedDataFeedId,
+                          updateId,
+                          oevUpdateTimestamp,
+                          encodeData(oevUpdateValue),
+                          roles.searcher.address,
+                          bidAmount,
+                          beacon.airnode.wallet,
+                          beacon.templateId
+                        );
+                        const packedOevUpdateSignature = packOevUpdateSignature(
+                          beacon.airnode.wallet.address,
+                          beacon.templateId,
+                          signature
+                        );
+                        await expect(
+                          dataFeedServerFull
+                            .connect(roles.searcher)
+                            .updateOevProxyDataFeedWithSignedData(
+                              oevProxy.address,
+                              spoofedDataFeedId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              [packedOevUpdateSignature],
+                              { value: bidAmount }
+                            )
+                        ).to.be.revertedWith('Beacon ID mismatch');
+                      });
+                    });
                   });
-                  await expect(
-                    dataFeedServerFull
-                      .connect(roles.searcher)
-                      .updateOevProxyDataFeedWithSignedData(
-                        oevProxy.address,
-                        beaconSet.beaconSetId,
-                        updateId,
-                        oevUpdateTimestamp,
-                        encodeData(oevUpdateValue),
-                        packedOevUpdateSignatures,
-                        { value: bidAmount }
-                      )
-                  ).to.be.revertedWith('ECDSA: invalid signature length');
-                });
-              });
-            });
-            context('One Beacon is specified', function () {
-              context('The signature is not invalid', function () {
-                context('The signature is not omitted', function () {
-                  context('Data in the packed signature is consistent with the data feed ID', function () {
-                    it('updates OEV proxy Beacon with signed data', async function () {
+                  context('The signature is omitted', function () {
+                    it('reverts', async function () {
                       const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                       const beacon = beacons[0];
-                      const oevUpdateValue = 105;
+                      await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
+                      const oevUpdateValue = 0;
                       const currentTimestamp = await helpers.time.latest();
                       const oevUpdateTimestamp = currentTimestamp + 1;
                       const bidAmount = 10000;
                       const updateId = testUtils.generateRandomBytes32();
-                      const signature = await testUtils.signOevData(
-                        dataFeedServerFull,
-                        oevProxy.address,
-                        beacon.beaconId,
-                        updateId,
-                        oevUpdateTimestamp,
-                        encodeData(oevUpdateValue),
-                        roles.searcher.address,
-                        bidAmount,
-                        beacon.airnode.wallet,
-                        beacon.templateId
-                      );
                       const packedOevUpdateSignature = packOevUpdateSignature(
                         beacon.airnode.wallet.address,
                         beacon.templateId,
-                        signature
+                        '0x'
                       );
-                      const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                      expect(beaconBefore.value).to.equal(0);
-                      expect(beaconBefore.timestamp).to.equal(0);
-                      const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                        oevProxy.address,
-                        beacon.beaconId
-                      );
-                      expect(oevProxyBeaconBefore.value).to.equal(0);
-                      expect(oevProxyBeaconBefore.timestamp).to.equal(0);
                       await expect(
                         dataFeedServerFull
                           .connect(roles.searcher)
@@ -3669,77 +4420,16 @@ describe('DataFeedServerFull', function () {
                             [packedOevUpdateSignature],
                             { value: bidAmount }
                           )
-                      )
-                        .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconWithSignedData')
-                        .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
-                      const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                      expect(beaconAfter.value).to.equal(0);
-                      expect(beaconAfter.timestamp).to.equal(0);
-                      const oevProxyBeaconAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                        oevProxy.address,
-                        beacon.beaconId
-                      );
-                      expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
-                      expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
-                    });
-                  });
-                  context('Data in the packed signature is not consistent with the data feed ID', function () {
-                    it('reverts', async function () {
-                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                      const beacon = beacons[0];
-                      const oevUpdateValue = 105;
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                      const signature = await testUtils.signOevData(
-                        dataFeedServerFull,
-                        oevProxy.address,
-                        spoofedDataFeedId,
-                        updateId,
-                        oevUpdateTimestamp,
-                        encodeData(oevUpdateValue),
-                        roles.searcher.address,
-                        bidAmount,
-                        beacon.airnode.wallet,
-                        beacon.templateId
-                      );
-                      const packedOevUpdateSignature = packOevUpdateSignature(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        signature
-                      );
-                      const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                      expect(beaconBefore.value).to.equal(0);
-                      expect(beaconBefore.timestamp).to.equal(0);
-                      const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                        oevProxy.address,
-                        beacon.beaconId
-                      );
-                      expect(oevProxyBeaconBefore.value).to.equal(0);
-                      expect(oevProxyBeaconBefore.timestamp).to.equal(0);
-                      await expect(
-                        dataFeedServerFull
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            spoofedDataFeedId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            [packedOevUpdateSignature],
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('Beacon ID mismatch');
+                      ).to.be.revertedWith('Missing signature');
                     });
                   });
                 });
-                context('The signature is omitted', function () {
+                context('The signature is invalid', function () {
                   it('reverts', async function () {
                     const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                     const beacon = beacons[0];
-                    const oevUpdateValue = 105;
+                    await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
+                    const oevUpdateValue = 0;
                     const currentTimestamp = await helpers.time.latest();
                     const oevUpdateTimestamp = currentTimestamp + 1;
                     const bidAmount = 10000;
@@ -3747,7 +4437,7 @@ describe('DataFeedServerFull', function () {
                     const packedOevUpdateSignature = packOevUpdateSignature(
                       beacon.airnode.wallet.address,
                       beacon.templateId,
-                      '0x'
+                      '0x123456'
                     );
                     await expect(
                       dataFeedServerFull
@@ -3761,24 +4451,20 @@ describe('DataFeedServerFull', function () {
                           [packedOevUpdateSignature],
                           { value: bidAmount }
                         )
-                    ).to.be.revertedWith('Missing signature');
+                    ).to.be.revertedWith('ECDSA: invalid signature length');
                   });
                 });
               });
-              context('The signature is invalid', function () {
+              context('No Beacon is specified', function () {
                 it('reverts', async function () {
                   const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                   const beacon = beacons[0];
-                  const oevUpdateValue = 105;
+                  await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
+                  const oevUpdateValue = 0;
                   const currentTimestamp = await helpers.time.latest();
                   const oevUpdateTimestamp = currentTimestamp + 1;
                   const bidAmount = 10000;
                   const updateId = testUtils.generateRandomBytes32();
-                  const packedOevUpdateSignature = packOevUpdateSignature(
-                    beacon.airnode.wallet.address,
-                    beacon.templateId,
-                    '0x123456'
-                  );
                   await expect(
                     dataFeedServerFull
                       .connect(roles.searcher)
@@ -3788,18 +4474,18 @@ describe('DataFeedServerFull', function () {
                         updateId,
                         oevUpdateTimestamp,
                         encodeData(oevUpdateValue),
-                        [packedOevUpdateSignature],
+                        [],
                         { value: bidAmount }
                       )
-                  ).to.be.revertedWith('ECDSA: invalid signature length');
+                  ).to.be.revertedWith('Did not specify any Beacons');
                 });
               });
             });
-            context('No Beacon is specified', function () {
+            context('Updated value same as base feed value', function () {
               it('reverts', async function () {
                 const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                 const beacon = beacons[0];
-                const oevUpdateValue = 105;
+                const oevUpdateValue = 0;
                 const currentTimestamp = await helpers.time.latest();
                 const oevUpdateTimestamp = currentTimestamp + 1;
                 const bidAmount = 10000;
@@ -3816,36 +4502,47 @@ describe('DataFeedServerFull', function () {
                       [],
                       { value: bidAmount }
                     )
-                ).to.be.revertedWith('Did not specify any Beacons');
+                ).to.be.revertedWith('Updated value same as base feed');
               });
             });
           });
-          context('Decoded fulfillment data cannot be typecasted into int224', function () {
+          context('Does not update timestamp', function () {
             it('reverts', async function () {
               const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
               const beacon = beacons[0];
-              const oevUpdateValueWithUnderflow = ethers.BigNumber.from(-2).pow(223).sub(1);
+              const oevUpdateValue = 105;
               const currentTimestamp = await helpers.time.latest();
               const oevUpdateTimestamp = currentTimestamp + 1;
               const bidAmount = 10000;
               const updateId = testUtils.generateRandomBytes32();
-              const signatureWithUnderflow = await testUtils.signOevData(
+              const signature = await testUtils.signOevData(
                 dataFeedServerFull,
                 oevProxy.address,
                 beacon.beaconId,
                 updateId,
                 oevUpdateTimestamp,
-                encodeData(oevUpdateValueWithUnderflow),
+                encodeData(oevUpdateValue),
                 roles.searcher.address,
                 bidAmount,
                 beacon.airnode.wallet,
                 beacon.templateId
               );
-              const packedOevUpdateSignatureWithUnderflow = packOevUpdateSignature(
+              const packedOevUpdateSignature = packOevUpdateSignature(
                 beacon.airnode.wallet.address,
                 beacon.templateId,
-                signatureWithUnderflow
+                signature
               );
+              await dataFeedServerFull
+                .connect(roles.searcher)
+                .updateOevProxyDataFeedWithSignedData(
+                  oevProxy.address,
+                  beacon.beaconId,
+                  updateId,
+                  oevUpdateTimestamp,
+                  encodeData(oevUpdateValue),
+                  [packedOevUpdateSignature],
+                  { value: bidAmount }
+                );
               await expect(
                 dataFeedServerFull
                   .connect(roles.searcher)
@@ -3854,70 +4551,39 @@ describe('DataFeedServerFull', function () {
                     beacon.beaconId,
                     updateId,
                     oevUpdateTimestamp,
-                    encodeData(oevUpdateValueWithUnderflow),
-                    [packedOevUpdateSignatureWithUnderflow],
+                    encodeData(oevUpdateValue),
+                    [packedOevUpdateSignature],
                     { value: bidAmount }
                   )
-              ).to.be.revertedWith('Value typecasting error');
-              const oevUpdateValueWithOverflow = ethers.BigNumber.from(2).pow(223);
-              const signatureWithOverflow = await testUtils.signOevData(
-                dataFeedServerFull,
-                oevProxy.address,
-                beacon.beaconId,
-                updateId,
-                oevUpdateTimestamp,
-                encodeData(oevUpdateValueWithOverflow),
-                roles.searcher.address,
-                bidAmount,
-                beacon.airnode.wallet,
-                beacon.templateId
-              );
-              const packedOevUpdateSignatureWithOverflow = packOevUpdateSignature(
-                beacon.airnode.wallet.address,
-                beacon.templateId,
-                signatureWithOverflow
-              );
-              await expect(
-                dataFeedServerFull
-                  .connect(roles.searcher)
-                  .updateOevProxyDataFeedWithSignedData(
-                    oevProxy.address,
-                    beacon.beaconId,
-                    updateId,
-                    oevUpdateTimestamp,
-                    encodeData(oevUpdateValueWithOverflow),
-                    [packedOevUpdateSignatureWithOverflow],
-                    { value: bidAmount }
-                  )
-              ).to.be.revertedWith('Value typecasting error');
+              ).to.be.revertedWith('Does not update timestamp');
             });
           });
         });
-        context('Fulfillment data length is not correct', function () {
+        context('Decoded fulfillment data cannot be typecasted into int224', function () {
           it('reverts', async function () {
             const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
             const beacon = beacons[0];
-            const oevUpdateValue = 105;
+            const oevUpdateValueWithUnderflow = ethers.BigNumber.from(-2).pow(223).sub(1);
             const currentTimestamp = await helpers.time.latest();
             const oevUpdateTimestamp = currentTimestamp + 1;
             const bidAmount = 10000;
             const updateId = testUtils.generateRandomBytes32();
-            const signature = await testUtils.signOevData(
+            const signatureWithUnderflow = await testUtils.signOevData(
               dataFeedServerFull,
               oevProxy.address,
               beacon.beaconId,
               updateId,
               oevUpdateTimestamp,
-              encodeData(oevUpdateValue) + '00',
+              encodeData(oevUpdateValueWithUnderflow),
               roles.searcher.address,
               bidAmount,
               beacon.airnode.wallet,
               beacon.templateId
             );
-            const packedOevUpdateSignature = packOevUpdateSignature(
+            const packedOevUpdateSignatureWithUnderflow = packOevUpdateSignature(
               beacon.airnode.wallet.address,
               beacon.templateId,
-              signature
+              signatureWithUnderflow
             );
             await expect(
               dataFeedServerFull
@@ -3927,15 +4593,46 @@ describe('DataFeedServerFull', function () {
                   beacon.beaconId,
                   updateId,
                   oevUpdateTimestamp,
-                  encodeData(oevUpdateValue) + '00',
-                  [packedOevUpdateSignature],
+                  encodeData(oevUpdateValueWithUnderflow),
+                  [packedOevUpdateSignatureWithUnderflow],
                   { value: bidAmount }
                 )
-            ).to.be.revertedWith('Data length not correct');
+            ).to.be.revertedWith('Value typecasting error');
+            const oevUpdateValueWithOverflow = ethers.BigNumber.from(2).pow(223);
+            const signatureWithOverflow = await testUtils.signOevData(
+              dataFeedServerFull,
+              oevProxy.address,
+              beacon.beaconId,
+              updateId,
+              oevUpdateTimestamp,
+              encodeData(oevUpdateValueWithOverflow),
+              roles.searcher.address,
+              bidAmount,
+              beacon.airnode.wallet,
+              beacon.templateId
+            );
+            const packedOevUpdateSignatureWithOverflow = packOevUpdateSignature(
+              beacon.airnode.wallet.address,
+              beacon.templateId,
+              signatureWithOverflow
+            );
+            await expect(
+              dataFeedServerFull
+                .connect(roles.searcher)
+                .updateOevProxyDataFeedWithSignedData(
+                  oevProxy.address,
+                  beacon.beaconId,
+                  updateId,
+                  oevUpdateTimestamp,
+                  encodeData(oevUpdateValueWithOverflow),
+                  [packedOevUpdateSignatureWithOverflow],
+                  { value: bidAmount }
+                )
+            ).to.be.revertedWith('Value typecasting error');
           });
         });
       });
-      context('Does not update timestamp', function () {
+      context('Fulfillment data length is not correct', function () {
         it('reverts', async function () {
           const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
           const beacon = beacons[0];
@@ -3950,7 +4647,7 @@ describe('DataFeedServerFull', function () {
             beacon.beaconId,
             updateId,
             oevUpdateTimestamp,
-            encodeData(oevUpdateValue),
+            encodeData(oevUpdateValue) + '00',
             roles.searcher.address,
             bidAmount,
             beacon.airnode.wallet,
@@ -3961,17 +4658,6 @@ describe('DataFeedServerFull', function () {
             beacon.templateId,
             signature
           );
-          await dataFeedServerFull
-            .connect(roles.searcher)
-            .updateOevProxyDataFeedWithSignedData(
-              oevProxy.address,
-              beacon.beaconId,
-              updateId,
-              oevUpdateTimestamp,
-              encodeData(oevUpdateValue),
-              [packedOevUpdateSignature],
-              { value: bidAmount }
-            );
           await expect(
             dataFeedServerFull
               .connect(roles.searcher)
@@ -3980,11 +4666,11 @@ describe('DataFeedServerFull', function () {
                 beacon.beaconId,
                 updateId,
                 oevUpdateTimestamp,
-                encodeData(oevUpdateValue),
+                encodeData(oevUpdateValue) + '00',
                 [packedOevUpdateSignature],
                 { value: bidAmount }
               )
-          ).to.be.revertedWith('Does not update timestamp');
+          ).to.be.revertedWith('Data length not correct');
         });
       });
     });
@@ -4011,20 +4697,6 @@ describe('DataFeedServerFull', function () {
               }
             )
         ).to.be.revertedWith('Timestamp not valid');
-      });
-    });
-    context('Timestamp is zero', function () {
-      it('reverts', async function () {
-        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-        const bidAmount = 10000;
-        const updateId = testUtils.generateRandomBytes32();
-        await expect(
-          dataFeedServerFull
-            .connect(roles.searcher)
-            .updateOevProxyDataFeedWithSignedData(oevProxy.address, updateId, beacons[0].beaconId, 0, '0x', ['0x'], {
-              value: bidAmount,
-            })
-        ).to.be.revertedWith('Does not update timestamp');
       });
     });
   });


### PR DESCRIPTION
Refer to https://api3workspace.slack.com/archives/C03GPUX7P71/p1678174457169759?thread_ts=1678101311.141659&cid=C03GPUX7P71 for context

Previous implementation:
- Beacon updates require timestamp to be updated
- Beacon set updates require timestamp or value to be updated
- OEV updates require timestamp to be updated

New implementation:
- Beacon updates require timestamp and value to be updated (not updating the value is allowed if the previous timestamp was zero)
- Beacon set updates require timestamp and value to be updated (not updating the value is allowed if the previous timestamp was zero)
- OEV updates require timestamp and value to be updated (not updating the value is allowed if the previous timestamp was zero), and require the value to be different than the value of the base data feed (even if the previous timestamp was zero)

Left the PSP functions as is and created an issue https://github.com/api3dao/airnode-protocol-v1/issues/114