### PR TITLE
Revert added update requirements

### DIFF
--- a/contracts/dapis/DataFeedServer.sol
+++ b/contracts/dapis/DataFeedServer.sol
@@ -51,12 +51,11 @@ contract DataFeedServer is ExtendedSelfMulticall, Median, IDataFeedServer {
         );
         beaconSetId = deriveBeaconSetId(beaconIds);
         DataFeed storage beaconSet = _dataFeeds[beaconSetId];
-        require(
-            updatedTimestamp > beaconSet.timestamp,
-            "Does not update timestamp"
-        );
-        if (beaconSet.timestamp != 0) {
-            require(updatedValue != beaconSet.value, "Does not update value");
+        if (beaconSet.timestamp == updatedTimestamp) {
+            require(
+                beaconSet.value != updatedValue,
+                "Does not update Beacon set"
+            );
         }
         _dataFeeds[beaconSetId] = DataFeed({
             value: updatedValue,
@@ -117,14 +116,10 @@ contract DataFeedServer is ExtendedSelfMulticall, Median, IDataFeedServer {
         returns (int224 updatedBeaconValue)
     {
         updatedBeaconValue = decodeFulfillmentData(data);
-        DataFeed storage beacon = _dataFeeds[beaconId];
-        require(timestamp > beacon.timestamp, "Does not update timestamp");
-        if (beacon.timestamp != 0) {
-            require(
-                updatedBeaconValue != beacon.value,
-                "Does not update value"
-            );
-        }
+        require(
+            timestamp > _dataFeeds[beaconId].timestamp,
+            "Does not update timestamp"
+        );
         _dataFeeds[beaconId] = DataFeed({
             value: updatedBeaconValue,
             timestamp: uint32(timestamp)

--- a/test/dapis/Api3ServerV1.sol.js
+++ b/test/dapis/Api3ServerV1.sol.js
@@ -57,50 +57,6 @@ describe('Api3ServerV1', function () {
     await api3ServerV1.connect(roles.randomPerson).multicall(updateBeaconSetCalldata);
   }
 
-  async function updateProxyDataFeed(
-    roles,
-    api3ServerV1,
-    oevProxyAddress,
-    beacons,
-    updateId,
-    dataFeedId,
-    decodedData,
-    timestamp
-  ) {
-    if (!timestamp) {
-      timestamp = await helpers.time.latest();
-    }
-    const data = encodeData(decodedData);
-    const packedOevUpdateSignatures = await Promise.all(
-      beacons.map(async (beacon) => {
-        const signature = await testUtils.signOevData(
-          api3ServerV1,
-          oevProxyAddress,
-          dataFeedId,
-          updateId,
-          timestamp,
-          data,
-          roles.searcher.address,
-          1,
-          beacon.airnode.wallet,
-          beacon.templateId
-        );
-        return packOevUpdateSignature(beacon.airnode.wallet.address, beacon.templateId, signature);
-      })
-    );
-    await api3ServerV1
-      .connect(roles.searcher)
-      .updateOevProxyDataFeedWithSignedData(
-        oevProxyAddress,
-        dataFeedId,
-        updateId,
-        timestamp,
-        data,
-        packedOevUpdateSignatures,
-        { value: 1 }
-      );
-  }
-
   function median(array) {
     if (array.length === 0) {
       throw new Error('Attempted to calculate median of empty array');
@@ -265,63 +221,11 @@ describe('Api3ServerV1', function () {
 
   describe('updateBeaconSetWithBeacons', function () {
     context('Did not specify less than two Beacons', function () {
-      context('Updates timestamp from a non-zero value', function () {
-        context('Updates value', function () {
-          it('updates Beacon set', async function () {
-            const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
-            // Populate the Beacons
-            const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
-            const currentTimestamp = await helpers.time.latest();
-            const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
-            await Promise.all(
-              beacons.map(async (beacon, index) => {
-                await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
-              })
-            );
-            const beaconSetValue = median(beaconValues);
-            const beaconSetTimestamp = median(beaconTimestamps);
-            const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetBefore.value).to.equal(0);
-            expect(beaconSetBefore.timestamp).to.equal(0);
-            expect(
-              await api3ServerV1.connect(roles.randomPerson).callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.equal(beaconSet.beaconSetId);
-            await expect(api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
-              .to.emit(api3ServerV1, 'UpdatedBeaconSetWithBeacons')
-              .withArgs(beaconSet.beaconSetId, beaconSetValue, beaconSetTimestamp);
-            const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetAfter.value).to.equal(beaconSetValue);
-            expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
-          });
-        });
-        context('Does not update value', function () {
-          it('reverts', async function () {
-            const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
-            // Populate the Beacons
-            const beaconValues = [100, 80, 120];
-            const currentTimestamp = await helpers.time.latest();
-            const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
-            await Promise.all(
-              beacons.map(async (beacon, index) => {
-                await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
-              })
-            );
-            // Update the Beacon set
-            await api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
-            // Update the Beacons in a way that it will not affect the aggregated value
-            await updateBeacon(roles, api3ServerV1, beacons[1], 79, currentTimestamp + 1);
-            await updateBeacon(roles, api3ServerV1, beacons[2], 121, currentTimestamp + 1);
-            await expect(
-              api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.be.revertedWith('Does not update value');
-          });
-        });
-      });
-      context('Updates timestamp from zero', function () {
+      context('Beacons update Beacon set timestamp', function () {
         it('updates Beacon set', async function () {
           const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
           // Populate the Beacons
-          const beaconValues = beacons.map(() => 0);
+          const beaconValues = beacons.map(() => Math.floor(Math.random() * 200 - 100));
           const currentTimestamp = await helpers.time.latest();
           const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
           await Promise.all(
@@ -345,25 +249,47 @@ describe('Api3ServerV1', function () {
           expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
         });
       });
-      context('Does not update timestamp', function () {
-        it('reverts', async function () {
-          const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
-          // Populate the Beacons
-          const beaconValues = [100, 80, 120];
-          const currentTimestamp = await helpers.time.latest();
-          const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
-          await Promise.all(
-            beacons.map(async (beacon, index) => {
-              await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
-            })
-          );
-          // Update the Beacon set
-          await api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
-          // Update the Beacons in a way that it will not affect the aggregated timestamp
-          await updateBeacon(roles, api3ServerV1, beacons[0], 101, currentTimestamp + 1);
-          await expect(
-            api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
-          ).to.be.revertedWith('Does not update timestamp');
+      context('Beacons do not update Beacon set timestamp', function () {
+        context('Beacons update Beacon set value', function () {
+          it('updates Beacon set', async function () {
+            const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
+            // Populate the Beacons
+            const beaconValues = [100, 80, 120];
+            const currentTimestamp = await helpers.time.latest();
+            const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
+            await Promise.all(
+              beacons.map(async (beacon, index) => {
+                await updateBeacon(roles, api3ServerV1, beacon, beaconValues[index], beaconTimestamps[index]);
+              })
+            );
+            const beaconIds = beacons.map((beacon) => {
+              return beacon.beaconId;
+            });
+            await api3ServerV1.updateBeaconSetWithBeacons(beaconIds);
+            await updateBeacon(roles, api3ServerV1, beacons[0], 110, currentTimestamp + 10);
+            const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetBefore.value).to.equal(100);
+            expect(beaconSetBefore.timestamp).to.equal(currentTimestamp);
+            expect(
+              await api3ServerV1.connect(roles.randomPerson).callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
+            ).to.equal(beaconSet.beaconSetId);
+            await expect(api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
+              .to.emit(api3ServerV1, 'UpdatedBeaconSetWithBeacons')
+              .withArgs(beaconSet.beaconSetId, 110, currentTimestamp);
+            const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetAfter.value).to.equal(110);
+            expect(beaconSetAfter.timestamp).to.equal(currentTimestamp);
+          });
+        });
+        context('Beacons do not update Beacon set value', function () {
+          it('reverts', async function () {
+            const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
+            // Update Beacon set with recent timestamp
+            await updateBeaconSet(roles, api3ServerV1, beacons, 123);
+            await expect(
+              api3ServerV1.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
+            ).to.be.revertedWith('Does not update Beacon set');
+          });
         });
       });
     });
@@ -385,87 +311,11 @@ describe('Api3ServerV1', function () {
       context('Signature is valid', function () {
         context('Fulfillment data length is correct', function () {
           context('Decoded fulfillment data can be typecasted into int224', function () {
-            context('Updates timestamp from a non-zero value', function () {
-              context('Updates value', function () {
-                it('updates Beacon with signed data', async function () {
-                  const { roles, api3ServerV1, beacons } = await deploy();
-                  const beacon = beacons[0];
-                  const beaconValue = Math.floor(Math.random() * 20000 - 10000);
-                  const beaconTimestamp = await helpers.time.latest();
-                  const signature = await testUtils.signData(
-                    beacon.airnode.wallet,
-                    beacon.templateId,
-                    beaconTimestamp,
-                    encodeData(beaconValue)
-                  );
-                  const beaconBefore = await api3ServerV1.dataFeeds(beacon.beaconId);
-                  expect(beaconBefore.value).to.equal(0);
-                  expect(beaconBefore.timestamp).to.equal(0);
-                  await expect(
-                    api3ServerV1
-                      .connect(roles.randomPerson)
-                      .updateBeaconWithSignedData(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beaconTimestamp,
-                        encodeData(beaconValue),
-                        signature
-                      )
-                  )
-                    .to.emit(api3ServerV1, 'UpdatedBeaconWithSignedData')
-                    .withArgs(beacon.beaconId, beaconValue, beaconTimestamp);
-                  const beaconAfter = await api3ServerV1.dataFeeds(beacon.beaconId);
-                  expect(beaconAfter.value).to.equal(beaconValue);
-                  expect(beaconAfter.timestamp).to.equal(beaconTimestamp);
-                });
-              });
-              context('Does not update value', function () {
-                it('reverts', async function () {
-                  const { roles, api3ServerV1, beacons } = await deploy();
-                  const beacon = beacons[0];
-                  const beaconValue = Math.floor(Math.random() * 20000 - 10000);
-                  const beaconTimestampFirst = await helpers.time.latest();
-                  const signatureFirst = await testUtils.signData(
-                    beacon.airnode.wallet,
-                    beacon.templateId,
-                    beaconTimestampFirst,
-                    encodeData(beaconValue)
-                  );
-                  await api3ServerV1
-                    .connect(roles.randomPerson)
-                    .updateBeaconWithSignedData(
-                      beacon.airnode.wallet.address,
-                      beacon.templateId,
-                      beaconTimestampFirst,
-                      encodeData(beaconValue),
-                      signatureFirst
-                    );
-                  const beaconTimestampSecond = await helpers.time.latest();
-                  const signatureSecond = await testUtils.signData(
-                    beacon.airnode.wallet,
-                    beacon.templateId,
-                    beaconTimestampSecond,
-                    encodeData(beaconValue)
-                  );
-                  await expect(
-                    api3ServerV1
-                      .connect(roles.randomPerson)
-                      .updateBeaconWithSignedData(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beaconTimestampSecond,
-                        encodeData(beaconValue),
-                        signatureSecond
-                      )
-                  ).to.be.revertedWith('Does not update value');
-                });
-              });
-            });
-            context('Updates timestamp from zero', function () {
+            context('Updates timestamp', function () {
               it('updates Beacon with signed data', async function () {
                 const { roles, api3ServerV1, beacons } = await deploy();
                 const beacon = beacons[0];
-                const beaconValue = 0;
+                const beaconValue = Math.floor(Math.random() * 200 - 100);
                 const beaconTimestamp = await helpers.time.latest();
                 const signature = await testUtils.signData(
                   beacon.airnode.wallet,
@@ -498,7 +348,7 @@ describe('Api3ServerV1', function () {
               it('reverts', async function () {
                 const { roles, api3ServerV1, beacons } = await deploy();
                 const beacon = beacons[0];
-                const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+                const beaconValue = Math.floor(Math.random() * 200 - 100);
                 const beaconTimestamp = await helpers.time.latest();
                 const signature = await testUtils.signData(
                   beacon.airnode.wallet,
@@ -577,7 +427,7 @@ describe('Api3ServerV1', function () {
           it('reverts', async function () {
             const { roles, api3ServerV1, beacons } = await deploy();
             const beacon = beacons[0];
-            const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconValue = Math.floor(Math.random() * 200 - 100);
             const beaconTimestamp = await helpers.time.latest();
             const signature = await testUtils.signData(
               beacon.airnode.wallet,
@@ -603,7 +453,7 @@ describe('Api3ServerV1', function () {
         it('reverts', async function () {
           const { roles, api3ServerV1, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           await expect(
             api3ServerV1
@@ -623,7 +473,7 @@ describe('Api3ServerV1', function () {
       it('reverts', async function () {
         const { roles, api3ServerV1, beacons } = await deploy();
         const beacon = beacons[0];
-        const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+        const beaconValue = Math.floor(Math.random() * 200 - 100);
         const nextTimestamp = (await helpers.time.latest()) + 1;
         await helpers.time.setNextBlockTimestamp(nextTimestamp);
         const beaconTimestamp = nextTimestamp + 60 * 60 + 1;
@@ -650,7 +500,7 @@ describe('Api3ServerV1', function () {
       it('reverts', async function () {
         const { roles, api3ServerV1, beacons } = await deploy();
         const beacon = beacons[0];
-        const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+        const beaconValue = Math.floor(Math.random() * 200 - 100);
         const nextTimestamp = (await helpers.time.latest()) + 1;
         await helpers.time.setNextBlockTimestamp(nextTimestamp);
         const beaconTimestamp = 0;
@@ -677,242 +527,15 @@ describe('Api3ServerV1', function () {
 
   describe('updateOevProxyDataFeedWithSignedData', function () {
     context('Timestamp is valid', function () {
-      context('Fulfillment data length is correct', function () {
-        context('Decoded fulfillment data can be typecasted into int224', function () {
-          context('Updates timestamp from a non-zero value', function () {
-            context('Updates value', function () {
-              context('Updated value not same as base feed value', function () {
-                context('More than one Beacon is specified', function () {
-                  context('There are no invalid signatures', function () {
-                    context('There are enough signatures to constitute an absolute majority', function () {
-                      context('Data in packed signatures is consistent with the data feed ID', function () {
-                        it('updates OEV proxy Beacon set with signed data', async function () {
-                          const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                          await updateProxyDataFeed(
-                            roles,
-                            api3ServerV1,
-                            oevProxy.address,
-                            beacons,
-                            testUtils.generateRandomBytes32(),
-                            beaconSet.beaconSetId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          // Randomly omit one of the signatures
-                          const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                          const signatures = await Promise.all(
-                            beacons.map(async (beacon, index) => {
-                              if (index === omitSignatureAtIndex) {
-                                return '0x';
-                              } else {
-                                return await testUtils.signOevData(
-                                  api3ServerV1,
-                                  oevProxy.address,
-                                  beaconSet.beaconSetId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  roles.searcher.address,
-                                  bidAmount,
-                                  beacon.airnode.wallet,
-                                  beacon.templateId
-                                );
-                              }
-                            })
-                          );
-                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                            return packOevUpdateSignature(
-                              beacons[index].airnode.wallet.address,
-                              beacons[index].templateId,
-                              signature
-                            );
-                          });
-                          const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-                          expect(beaconSetBefore.value).to.equal(0);
-                          expect(beaconSetBefore.timestamp).to.equal(0);
-                          const oevProxyBeaconSetBefore = await api3ServerV1.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beaconSet.beaconSetId
-                          );
-                          expect(oevProxyBeaconSetBefore.value).to.equal(1);
-                          expect(oevProxyBeaconSetBefore.timestamp).to.equal(1);
-                          await expect(
-                            api3ServerV1
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                packedOevUpdateSignatures,
-                                { value: bidAmount }
-                              )
-                          )
-                            .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconSetWithSignedData')
-                            .withArgs(
-                              beaconSet.beaconSetId,
-                              oevProxy.address,
-                              updateId,
-                              oevUpdateValue,
-                              oevUpdateTimestamp
-                            );
-                          const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-                          expect(beaconSetAfter.value).to.equal(0);
-                          expect(beaconSetAfter.timestamp).to.equal(0);
-                          const oevProxyBeaconSetAfter = await api3ServerV1.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beaconSet.beaconSetId
-                          );
-                          expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
-                          expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
-                        });
-                      });
-                      context('Data in packed signatures is not consistent with the data feed ID', function () {
-                        it('reverts', async function () {
-                          const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                          await updateProxyDataFeed(
-                            roles,
-                            api3ServerV1,
-                            oevProxy.address,
-                            beacons,
-                            testUtils.generateRandomBytes32(),
-                            beaconSet.beaconSetId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          // Randomly omit one of the signatures
-                          const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                          const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                          const signatures = await Promise.all(
-                            beacons.map(async (beacon, index) => {
-                              if (index === omitSignatureAtIndex) {
-                                return '0x';
-                              } else {
-                                return await testUtils.signOevData(
-                                  api3ServerV1,
-                                  oevProxy.address,
-                                  spoofedDataFeedId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  roles.searcher.address,
-                                  bidAmount,
-                                  beacon.airnode.wallet,
-                                  beacon.templateId
-                                );
-                              }
-                            })
-                          );
-                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                            return packOevUpdateSignature(
-                              beacons[index].airnode.wallet.address,
-                              beacons[index].templateId,
-                              signature
-                            );
-                          });
-                          await expect(
-                            api3ServerV1
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                spoofedDataFeedId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                packedOevUpdateSignatures,
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Beacon set ID mismatch');
-                        });
-                      });
-                    });
-                    context('There are not enough signatures to constitute an absolute majority', function () {
-                      it('reverts', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                        await updateProxyDataFeed(
-                          roles,
-                          api3ServerV1,
-                          oevProxy.address,
-                          beacons,
-                          testUtils.generateRandomBytes32(),
-                          beaconSet.beaconSetId,
-                          1,
-                          1
-                        );
-                        const oevUpdateValue = 105;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit two of the signatures
-                        const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index !== includeSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return await testUtils.signOevData(
-                                api3ServerV1,
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                roles.searcher.address,
-                                bidAmount,
-                                beacon.airnode.wallet,
-                                beacon.templateId
-                              );
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beaconSet.beaconSetId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Not enough signatures');
-                      });
-                    });
-                  });
-                  context('There are invalid signatures', function () {
-                    it('reverts', async function () {
+      context('Updates timestamp', function () {
+        context('Fulfillment data length is correct', function () {
+          context('Decoded fulfillment data can be typecasted into int224', function () {
+            context('More than one Beacon is specified', function () {
+              context('There are no invalid signatures', function () {
+                context('There are enough signatures to constitute an absolute majority', function () {
+                  context('Data in packed signatures is consistent with the data feed ID', function () {
+                    it('updates OEV proxy Beacon set with signed data', async function () {
                       const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                      await updateProxyDataFeed(
-                        roles,
-                        api3ServerV1,
-                        oevProxy.address,
-                        beacons,
-                        testUtils.generateRandomBytes32(),
-                        beaconSet.beaconSetId,
-                        1,
-                        1
-                      );
                       const oevUpdateValue = 105;
                       const currentTimestamp = await helpers.time.latest();
                       const oevUpdateTimestamp = currentTimestamp + 1;
@@ -923,1064 +546,6 @@ describe('Api3ServerV1', function () {
                       const signatures = await Promise.all(
                         beacons.map(async (beacon, index) => {
                           if (index === omitSignatureAtIndex) {
-                            return '0x';
-                          } else {
-                            return '0x123456';
-                          }
-                        })
-                      );
-                      const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                        return packOevUpdateSignature(
-                          beacons[index].airnode.wallet.address,
-                          beacons[index].templateId,
-                          signature
-                        );
-                      });
-                      await expect(
-                        api3ServerV1
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beaconSet.beaconSetId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            packedOevUpdateSignatures,
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('ECDSA: invalid signature length');
-                    });
-                  });
-                });
-                context('One Beacon is specified', function () {
-                  context('The signature is not invalid', function () {
-                    context('The signature is not omitted', function () {
-                      context('Data in the packed signature is consistent with the data feed ID', function () {
-                        it('updates OEV proxy Beacon with signed data', async function () {
-                          const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                          const beacon = beacons[0];
-                          await updateProxyDataFeed(
-                            roles,
-                            api3ServerV1,
-                            oevProxy.address,
-                            [beacon],
-                            testUtils.generateRandomBytes32(),
-                            beacon.beaconId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          const signature = await testUtils.signOevData(
-                            api3ServerV1,
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            roles.searcher.address,
-                            bidAmount,
-                            beacon.airnode.wallet,
-                            beacon.templateId
-                          );
-                          const packedOevUpdateSignature = packOevUpdateSignature(
-                            beacon.airnode.wallet.address,
-                            beacon.templateId,
-                            signature
-                          );
-                          const beaconBefore = await api3ServerV1.dataFeeds(beacon.beaconId);
-                          expect(beaconBefore.value).to.equal(0);
-                          expect(beaconBefore.timestamp).to.equal(0);
-                          const oevProxyBeaconBefore = await api3ServerV1.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beacon.beaconId
-                          );
-                          expect(oevProxyBeaconBefore.value).to.equal(1);
-                          expect(oevProxyBeaconBefore.timestamp).to.equal(1);
-                          await expect(
-                            api3ServerV1
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beacon.beaconId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                [packedOevUpdateSignature],
-                                { value: bidAmount }
-                              )
-                          )
-                            .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconWithSignedData')
-                            .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
-                          const beaconAfter = await api3ServerV1.dataFeeds(beacon.beaconId);
-                          expect(beaconAfter.value).to.equal(0);
-                          expect(beaconAfter.timestamp).to.equal(0);
-                          const oevProxyBeaconAfter = await api3ServerV1.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beacon.beaconId
-                          );
-                          expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
-                          expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
-                        });
-                      });
-                      context('Data in the packed signature is not consistent with the data feed ID', function () {
-                        it('reverts', async function () {
-                          const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                          const beacon = beacons[0];
-                          await updateProxyDataFeed(
-                            roles,
-                            api3ServerV1,
-                            oevProxy.address,
-                            [beacon],
-                            testUtils.generateRandomBytes32(),
-                            beacon.beaconId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                          const signature = await testUtils.signOevData(
-                            api3ServerV1,
-                            oevProxy.address,
-                            spoofedDataFeedId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            roles.searcher.address,
-                            bidAmount,
-                            beacon.airnode.wallet,
-                            beacon.templateId
-                          );
-                          const packedOevUpdateSignature = packOevUpdateSignature(
-                            beacon.airnode.wallet.address,
-                            beacon.templateId,
-                            signature
-                          );
-                          await expect(
-                            api3ServerV1
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                spoofedDataFeedId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                [packedOevUpdateSignature],
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Beacon ID mismatch');
-                        });
-                      });
-                    });
-                    context('The signature is omitted', function () {
-                      it('reverts', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        await updateProxyDataFeed(
-                          roles,
-                          api3ServerV1,
-                          oevProxy.address,
-                          [beacon],
-                          testUtils.generateRandomBytes32(),
-                          beacon.beaconId,
-                          1,
-                          1
-                        );
-                        const oevUpdateValue = 105;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          '0x'
-                        );
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Missing signature');
-                      });
-                    });
-                  });
-                  context('The signature is invalid', function () {
-                    it('reverts', async function () {
-                      const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                      const beacon = beacons[0];
-                      await updateProxyDataFeed(
-                        roles,
-                        api3ServerV1,
-                        oevProxy.address,
-                        [beacon],
-                        testUtils.generateRandomBytes32(),
-                        beacon.beaconId,
-                        1,
-                        1
-                      );
-                      const oevUpdateValue = 105;
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      const packedOevUpdateSignature = packOevUpdateSignature(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        '0x123456'
-                      );
-                      await expect(
-                        api3ServerV1
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            [packedOevUpdateSignature],
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('ECDSA: invalid signature length');
-                    });
-                  });
-                });
-                context('No Beacon is specified', function () {
-                  it('reverts', async function () {
-                    const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                    const beacon = beacons[0];
-                    await updateProxyDataFeed(
-                      roles,
-                      api3ServerV1,
-                      oevProxy.address,
-                      [beacon],
-                      testUtils.generateRandomBytes32(),
-                      beacon.beaconId,
-                      1,
-                      1
-                    );
-                    const oevUpdateValue = 105;
-                    const currentTimestamp = await helpers.time.latest();
-                    const oevUpdateTimestamp = currentTimestamp + 1;
-                    const bidAmount = 10000;
-                    const updateId = testUtils.generateRandomBytes32();
-                    await expect(
-                      api3ServerV1
-                        .connect(roles.searcher)
-                        .updateOevProxyDataFeedWithSignedData(
-                          oevProxy.address,
-                          beacon.beaconId,
-                          updateId,
-                          oevUpdateTimestamp,
-                          encodeData(oevUpdateValue),
-                          [],
-                          { value: bidAmount }
-                        )
-                    ).to.be.revertedWith('Did not specify any Beacons');
-                  });
-                });
-              });
-              context('Updated value same as base feed value', function () {
-                context('Current OEV proxy data feed timestamp is larger than base data feed timestamp', function () {
-                  context('More than one Beacon is specified', function () {
-                    context('There are no invalid signatures', function () {
-                      context('There are enough signatures to constitute an absolute majority', function () {
-                        context('Data in packed signatures is consistent with the data feed ID', function () {
-                          it('updates OEV proxy Beacon set with signed data', async function () {
-                            const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                            await updateProxyDataFeed(
-                              roles,
-                              api3ServerV1,
-                              oevProxy.address,
-                              beacons,
-                              testUtils.generateRandomBytes32(),
-                              beaconSet.beaconSetId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeaconSet(roles, api3ServerV1, beacons, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            // Randomly omit one of the signatures
-                            const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                            const signatures = await Promise.all(
-                              beacons.map(async (beacon, index) => {
-                                if (index === omitSignatureAtIndex) {
-                                  return '0x';
-                                } else {
-                                  return await testUtils.signOevData(
-                                    api3ServerV1,
-                                    oevProxy.address,
-                                    beaconSet.beaconSetId,
-                                    updateId,
-                                    oevUpdateTimestamp,
-                                    encodeData(oevUpdateValue),
-                                    roles.searcher.address,
-                                    bidAmount,
-                                    beacon.airnode.wallet,
-                                    beacon.templateId
-                                  );
-                                }
-                              })
-                            );
-                            const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                              return packOevUpdateSignature(
-                                beacons[index].airnode.wallet.address,
-                                beacons[index].templateId,
-                                signature
-                              );
-                            });
-                            const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-                            expect(beaconSetBefore.value).to.equal(105);
-                            expect(beaconSetBefore.timestamp).to.equal(1);
-                            const oevProxyBeaconSetBefore = await api3ServerV1.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beaconSet.beaconSetId
-                            );
-                            expect(oevProxyBeaconSetBefore.value).to.equal(1);
-                            expect(oevProxyBeaconSetBefore.timestamp).to.equal(2);
-                            await expect(
-                              api3ServerV1
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  beaconSet.beaconSetId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  packedOevUpdateSignatures,
-                                  { value: bidAmount }
-                                )
-                            )
-                              .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconSetWithSignedData')
-                              .withArgs(
-                                beaconSet.beaconSetId,
-                                oevProxy.address,
-                                updateId,
-                                oevUpdateValue,
-                                oevUpdateTimestamp
-                              );
-                            const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-                            expect(beaconSetAfter.value).to.equal(105);
-                            expect(beaconSetAfter.timestamp).to.equal(1);
-                            const oevProxyBeaconSetAfter = await api3ServerV1.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beaconSet.beaconSetId
-                            );
-                            expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
-                            expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
-                          });
-                        });
-                        context('Data in packed signatures is not consistent with the data feed ID', function () {
-                          it('reverts', async function () {
-                            const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                            await updateProxyDataFeed(
-                              roles,
-                              api3ServerV1,
-                              oevProxy.address,
-                              beacons,
-                              testUtils.generateRandomBytes32(),
-                              beaconSet.beaconSetId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeaconSet(roles, api3ServerV1, beacons, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            // Randomly omit one of the signatures
-                            const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                            const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                            const signatures = await Promise.all(
-                              beacons.map(async (beacon, index) => {
-                                if (index === omitSignatureAtIndex) {
-                                  return '0x';
-                                } else {
-                                  return await testUtils.signOevData(
-                                    api3ServerV1,
-                                    oevProxy.address,
-                                    spoofedDataFeedId,
-                                    updateId,
-                                    oevUpdateTimestamp,
-                                    encodeData(oevUpdateValue),
-                                    roles.searcher.address,
-                                    bidAmount,
-                                    beacon.airnode.wallet,
-                                    beacon.templateId
-                                  );
-                                }
-                              })
-                            );
-                            const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                              return packOevUpdateSignature(
-                                beacons[index].airnode.wallet.address,
-                                beacons[index].templateId,
-                                signature
-                              );
-                            });
-                            await expect(
-                              api3ServerV1
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  spoofedDataFeedId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  packedOevUpdateSignatures,
-                                  { value: bidAmount }
-                                )
-                            ).to.be.revertedWith('Beacon set ID mismatch');
-                          });
-                        });
-                      });
-                      context('There are not enough signatures to constitute an absolute majority', function () {
-                        it('reverts', async function () {
-                          const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                          await updateProxyDataFeed(
-                            roles,
-                            api3ServerV1,
-                            oevProxy.address,
-                            beacons,
-                            testUtils.generateRandomBytes32(),
-                            beaconSet.beaconSetId,
-                            1,
-                            2
-                          );
-                          const oevUpdateValue = 105;
-                          await updateBeaconSet(roles, api3ServerV1, beacons, oevUpdateValue, 1);
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          // Randomly omit two of the signatures
-                          const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                          const signatures = await Promise.all(
-                            beacons.map(async (beacon, index) => {
-                              if (index !== includeSignatureAtIndex) {
-                                return '0x';
-                              } else {
-                                return await testUtils.signOevData(
-                                  api3ServerV1,
-                                  oevProxy.address,
-                                  beaconSet.beaconSetId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  roles.searcher.address,
-                                  bidAmount,
-                                  beacon.airnode.wallet,
-                                  beacon.templateId
-                                );
-                              }
-                            })
-                          );
-                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                            return packOevUpdateSignature(
-                              beacons[index].airnode.wallet.address,
-                              beacons[index].templateId,
-                              signature
-                            );
-                          });
-                          await expect(
-                            api3ServerV1
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                packedOevUpdateSignatures,
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Not enough signatures');
-                        });
-                      });
-                    });
-                    context('There are invalid signatures', function () {
-                      it('reverts', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                        await updateProxyDataFeed(
-                          roles,
-                          api3ServerV1,
-                          oevProxy.address,
-                          beacons,
-                          testUtils.generateRandomBytes32(),
-                          beaconSet.beaconSetId,
-                          1,
-                          2
-                        );
-                        const oevUpdateValue = 105;
-                        await updateBeaconSet(roles, api3ServerV1, beacons, oevUpdateValue, 1);
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit one of the signatures
-                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index === omitSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return '0x123456';
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beaconSet.beaconSetId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('ECDSA: invalid signature length');
-                      });
-                    });
-                  });
-                  context('One Beacon is specified', function () {
-                    context('The signature is not invalid', function () {
-                      context('The signature is not omitted', function () {
-                        context('Data in the packed signature is consistent with the data feed ID', function () {
-                          it('updates OEV proxy Beacon with signed data', async function () {
-                            const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                            const beacon = beacons[0];
-                            await updateProxyDataFeed(
-                              roles,
-                              api3ServerV1,
-                              oevProxy.address,
-                              [beacon],
-                              testUtils.generateRandomBytes32(),
-                              beacon.beaconId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeacon(roles, api3ServerV1, beacon, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            const signature = await testUtils.signOevData(
-                              api3ServerV1,
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              roles.searcher.address,
-                              bidAmount,
-                              beacon.airnode.wallet,
-                              beacon.templateId
-                            );
-                            const packedOevUpdateSignature = packOevUpdateSignature(
-                              beacon.airnode.wallet.address,
-                              beacon.templateId,
-                              signature
-                            );
-                            const beaconBefore = await api3ServerV1.dataFeeds(beacon.beaconId);
-                            expect(beaconBefore.value).to.equal(105);
-                            expect(beaconBefore.timestamp).to.equal(1);
-                            const oevProxyBeaconBefore = await api3ServerV1.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beacon.beaconId
-                            );
-                            expect(oevProxyBeaconBefore.value).to.equal(1);
-                            expect(oevProxyBeaconBefore.timestamp).to.equal(2);
-                            await expect(
-                              api3ServerV1
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  beacon.beaconId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  [packedOevUpdateSignature],
-                                  { value: bidAmount }
-                                )
-                            )
-                              .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconWithSignedData')
-                              .withArgs(
-                                beacon.beaconId,
-                                oevProxy.address,
-                                updateId,
-                                oevUpdateValue,
-                                oevUpdateTimestamp
-                              );
-                            const beaconAfter = await api3ServerV1.dataFeeds(beacon.beaconId);
-                            expect(beaconAfter.value).to.equal(105);
-                            expect(beaconAfter.timestamp).to.equal(1);
-                            const oevProxyBeaconAfter = await api3ServerV1.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beacon.beaconId
-                            );
-                            expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
-                            expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
-                          });
-                        });
-                        context('Data in the packed signature is not consistent with the data feed ID', function () {
-                          it('reverts', async function () {
-                            const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                            const beacon = beacons[0];
-                            await updateProxyDataFeed(
-                              roles,
-                              api3ServerV1,
-                              oevProxy.address,
-                              [beacon],
-                              testUtils.generateRandomBytes32(),
-                              beacon.beaconId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeacon(roles, api3ServerV1, beacon, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                            const signature = await testUtils.signOevData(
-                              api3ServerV1,
-                              oevProxy.address,
-                              spoofedDataFeedId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              roles.searcher.address,
-                              bidAmount,
-                              beacon.airnode.wallet,
-                              beacon.templateId
-                            );
-                            const packedOevUpdateSignature = packOevUpdateSignature(
-                              beacon.airnode.wallet.address,
-                              beacon.templateId,
-                              signature
-                            );
-                            await expect(
-                              api3ServerV1
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  spoofedDataFeedId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  [packedOevUpdateSignature],
-                                  { value: bidAmount }
-                                )
-                            ).to.be.revertedWith('Beacon ID mismatch');
-                          });
-                        });
-                      });
-                      context('The signature is omitted', function () {
-                        it('reverts', async function () {
-                          const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                          const beacon = beacons[0];
-                          await updateProxyDataFeed(
-                            roles,
-                            api3ServerV1,
-                            oevProxy.address,
-                            [beacon],
-                            testUtils.generateRandomBytes32(),
-                            beacon.beaconId,
-                            1,
-                            2
-                          );
-                          const oevUpdateValue = 105;
-                          await updateBeacon(roles, api3ServerV1, beacon, oevUpdateValue, 1);
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          const packedOevUpdateSignature = packOevUpdateSignature(
-                            beacon.airnode.wallet.address,
-                            beacon.templateId,
-                            '0x'
-                          );
-                          await expect(
-                            api3ServerV1
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beacon.beaconId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                [packedOevUpdateSignature],
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Missing signature');
-                        });
-                      });
-                    });
-                    context('The signature is invalid', function () {
-                      it('reverts', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        await updateProxyDataFeed(
-                          roles,
-                          api3ServerV1,
-                          oevProxy.address,
-                          [beacon],
-                          testUtils.generateRandomBytes32(),
-                          beacon.beaconId,
-                          1,
-                          2
-                        );
-                        const oevUpdateValue = 105;
-                        await updateBeacon(roles, api3ServerV1, beacon, oevUpdateValue, 1);
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          '0x123456'
-                        );
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('ECDSA: invalid signature length');
-                      });
-                    });
-                  });
-                  context('No Beacon is specified', function () {
-                    it('reverts', async function () {
-                      const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                      const beacon = beacons[0];
-                      await updateProxyDataFeed(
-                        roles,
-                        api3ServerV1,
-                        oevProxy.address,
-                        [beacon],
-                        testUtils.generateRandomBytes32(),
-                        beacon.beaconId,
-                        1,
-                        2
-                      );
-                      const oevUpdateValue = 105;
-                      await updateBeacon(roles, api3ServerV1, beacon, oevUpdateValue, 1);
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      await expect(
-                        api3ServerV1
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            [],
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('Did not specify any Beacons');
-                    });
-                  });
-                });
-                context(
-                  'Current OEV proxy data feed timestamp is not larger than base data feed timestamp',
-                  function () {
-                    it('reverts', async function () {
-                      const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                      const beacon = beacons[0];
-                      const oevUpdateValue = 105;
-                      await updateBeacon(roles, api3ServerV1, beacon, oevUpdateValue, 1);
-                      const updateId = testUtils.generateRandomBytes32();
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const signature = await testUtils.signOevData(
-                        api3ServerV1,
-                        oevProxy.address,
-                        beacon.beaconId,
-                        updateId,
-                        oevUpdateTimestamp,
-                        encodeData(oevUpdateValue),
-                        roles.searcher.address,
-                        bidAmount,
-                        beacon.airnode.wallet,
-                        beacon.templateId
-                      );
-                      const packedOevUpdateSignature = packOevUpdateSignature(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        signature
-                      );
-                      await expect(
-                        api3ServerV1
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            [packedOevUpdateSignature],
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('Repeats base feed update');
-                    });
-                  }
-                );
-              });
-            });
-            context('Does not update value', function () {
-              it('reverts', async function () {
-                const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                const beacon = beacons[0];
-                const oevUpdateValue = 105;
-                await updateProxyDataFeed(
-                  roles,
-                  api3ServerV1,
-                  oevProxy.address,
-                  [beacon],
-                  testUtils.generateRandomBytes32(),
-                  beacon.beaconId,
-                  oevUpdateValue,
-                  1
-                );
-                const updateId = testUtils.generateRandomBytes32();
-                const currentTimestamp = await helpers.time.latest();
-                const oevUpdateTimestamp = currentTimestamp + 1;
-                const bidAmount = 10000;
-                const signature = await testUtils.signOevData(
-                  api3ServerV1,
-                  oevProxy.address,
-                  beacon.beaconId,
-                  updateId,
-                  oevUpdateTimestamp,
-                  encodeData(oevUpdateValue),
-                  roles.searcher.address,
-                  bidAmount,
-                  beacon.airnode.wallet,
-                  beacon.templateId
-                );
-                const packedOevUpdateSignature = packOevUpdateSignature(
-                  beacon.airnode.wallet.address,
-                  beacon.templateId,
-                  signature
-                );
-                await expect(
-                  api3ServerV1
-                    .connect(roles.searcher)
-                    .updateOevProxyDataFeedWithSignedData(
-                      oevProxy.address,
-                      beacon.beaconId,
-                      updateId,
-                      oevUpdateTimestamp,
-                      encodeData(oevUpdateValue),
-                      [packedOevUpdateSignature],
-                      { value: bidAmount }
-                    )
-                ).to.be.revertedWith('Does not update value');
-              });
-            });
-          });
-          context('Updates timestamp from zero', function () {
-            context('Updated value not same as base feed value', function () {
-              context('More than one Beacon is specified', function () {
-                context('There are no invalid signatures', function () {
-                  context('There are enough signatures to constitute an absolute majority', function () {
-                    context('Data in packed signatures is consistent with the data feed ID', function () {
-                      it('updates OEV proxy Beacon set with signed data', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                        await updateBeaconSet(roles, api3ServerV1, beacons, 1, 1);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit one of the signatures
-                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index === omitSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return await testUtils.signOevData(
-                                api3ServerV1,
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                roles.searcher.address,
-                                bidAmount,
-                                beacon.airnode.wallet,
-                                beacon.templateId
-                              );
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-                        expect(beaconSetBefore.value).to.equal(1);
-                        expect(beaconSetBefore.timestamp).to.equal(1);
-                        const oevProxyBeaconSetBefore = await api3ServerV1.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beaconSet.beaconSetId
-                        );
-                        expect(oevProxyBeaconSetBefore.value).to.equal(0);
-                        expect(oevProxyBeaconSetBefore.timestamp).to.equal(0);
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beaconSet.beaconSetId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        )
-                          .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconSetWithSignedData')
-                          .withArgs(
-                            beaconSet.beaconSetId,
-                            oevProxy.address,
-                            updateId,
-                            oevUpdateValue,
-                            oevUpdateTimestamp
-                          );
-                        const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
-                        expect(beaconSetAfter.value).to.equal(1);
-                        expect(beaconSetAfter.timestamp).to.equal(1);
-                        const oevProxyBeaconSetAfter = await api3ServerV1.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beaconSet.beaconSetId
-                        );
-                        expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
-                        expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
-                      });
-                    });
-                    context('Data in packed signatures is not consistent with the data feed ID', function () {
-                      it('reverts', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                        const spoofedDataFeedId = ethers.utils.keccak256(
-                          ethers.utils.defaultAbiCoder.encode(
-                            ['bytes32[]'],
-                            [[beacons[0].beaconId, beacons[1].beaconId]]
-                          )
-                        );
-                        await updateBeaconSet(roles, api3ServerV1, beacons, 1, 1);
-                        await api3ServerV1.updateBeaconSetWithBeacons([beacons[0].beaconId, beacons[1].beaconId]);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit one of the signatures
-                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index === omitSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return await testUtils.signOevData(
-                                api3ServerV1,
-                                oevProxy.address,
-                                spoofedDataFeedId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                roles.searcher.address,
-                                bidAmount,
-                                beacon.airnode.wallet,
-                                beacon.templateId
-                              );
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              spoofedDataFeedId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Beacon set ID mismatch');
-                      });
-                    });
-                  });
-                  context('There are not enough signatures to constitute an absolute majority', function () {
-                    it('reverts', async function () {
-                      const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                      await updateBeaconSet(roles, api3ServerV1, beacons, 1, 1);
-                      const oevUpdateValue = 0;
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      // Randomly omit two of the signatures
-                      const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                      const signatures = await Promise.all(
-                        beacons.map(async (beacon, index) => {
-                          if (index !== includeSignatureAtIndex) {
                             return '0x';
                           } else {
                             return await testUtils.signOevData(
@@ -2005,6 +570,15 @@ describe('Api3ServerV1', function () {
                           signature
                         );
                       });
+                      const beaconSetBefore = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
+                      expect(beaconSetBefore.value).to.equal(0);
+                      expect(beaconSetBefore.timestamp).to.equal(0);
+                      const oevProxyBeaconSetBefore = await api3ServerV1.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beaconSet.beaconSetId
+                      );
+                      expect(oevProxyBeaconSetBefore.value).to.equal(0);
+                      expect(oevProxyBeaconSetBefore.timestamp).to.equal(0);
                       await expect(
                         api3ServerV1
                           .connect(roles.searcher)
@@ -2017,27 +591,107 @@ describe('Api3ServerV1', function () {
                             packedOevUpdateSignatures,
                             { value: bidAmount }
                           )
-                      ).to.be.revertedWith('Not enough signatures');
+                      )
+                        .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconSetWithSignedData')
+                        .withArgs(
+                          beaconSet.beaconSetId,
+                          oevProxy.address,
+                          updateId,
+                          oevUpdateValue,
+                          oevUpdateTimestamp
+                        );
+                      const beaconSetAfter = await api3ServerV1.dataFeeds(beaconSet.beaconSetId);
+                      expect(beaconSetAfter.value).to.equal(0);
+                      expect(beaconSetAfter.timestamp).to.equal(0);
+                      const oevProxyBeaconSetAfter = await api3ServerV1.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beaconSet.beaconSetId
+                      );
+                      expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
+                      expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
+                    });
+                  });
+                  context('Data in packed signatures is not consistent with the data feed ID', function () {
+                    it('reverts', async function () {
+                      const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
+                      const oevUpdateValue = 105;
+                      const currentTimestamp = await helpers.time.latest();
+                      const oevUpdateTimestamp = currentTimestamp + 1;
+                      const bidAmount = 10000;
+                      const updateId = testUtils.generateRandomBytes32();
+                      // Randomly omit one of the signatures
+                      const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                      const spoofedDataFeedId = testUtils.generateRandomBytes32();
+                      const signatures = await Promise.all(
+                        beacons.map(async (beacon, index) => {
+                          if (index === omitSignatureAtIndex) {
+                            return '0x';
+                          } else {
+                            return await testUtils.signOevData(
+                              api3ServerV1,
+                              oevProxy.address,
+                              spoofedDataFeedId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              roles.searcher.address,
+                              bidAmount,
+                              beacon.airnode.wallet,
+                              beacon.templateId
+                            );
+                          }
+                        })
+                      );
+                      const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                        return packOevUpdateSignature(
+                          beacons[index].airnode.wallet.address,
+                          beacons[index].templateId,
+                          signature
+                        );
+                      });
+                      await expect(
+                        api3ServerV1
+                          .connect(roles.searcher)
+                          .updateOevProxyDataFeedWithSignedData(
+                            oevProxy.address,
+                            spoofedDataFeedId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            packedOevUpdateSignatures,
+                            { value: bidAmount }
+                          )
+                      ).to.be.revertedWith('Beacon set ID mismatch');
                     });
                   });
                 });
-                context('There are invalid signatures', function () {
+                context('There are not enough signatures to constitute an absolute majority', function () {
                   it('reverts', async function () {
                     const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
-                    await updateBeaconSet(roles, api3ServerV1, beacons, 1, 1);
-                    const oevUpdateValue = 0;
+                    const oevUpdateValue = 105;
                     const currentTimestamp = await helpers.time.latest();
                     const oevUpdateTimestamp = currentTimestamp + 1;
                     const bidAmount = 10000;
                     const updateId = testUtils.generateRandomBytes32();
-                    // Randomly omit one of the signatures
-                    const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                    // Randomly omit two of the signatures
+                    const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
                     const signatures = await Promise.all(
                       beacons.map(async (beacon, index) => {
-                        if (index === omitSignatureAtIndex) {
+                        if (index !== includeSignatureAtIndex) {
                           return '0x';
                         } else {
-                          return '0x123456';
+                          return await testUtils.signOevData(
+                            api3ServerV1,
+                            oevProxy.address,
+                            beaconSet.beaconSetId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            roles.searcher.address,
+                            bidAmount,
+                            beacon.airnode.wallet,
+                            beacon.templateId
+                          );
                         }
                       })
                     );
@@ -2060,135 +714,90 @@ describe('Api3ServerV1', function () {
                           packedOevUpdateSignatures,
                           { value: bidAmount }
                         )
-                    ).to.be.revertedWith('ECDSA: invalid signature length');
+                    ).to.be.revertedWith('Not enough signatures');
                   });
                 });
               });
-              context('One Beacon is specified', function () {
-                context('The signature is not invalid', function () {
-                  context('The signature is not omitted', function () {
-                    context('Data in the packed signature is consistent with the data feed ID', function () {
-                      it('updates OEV proxy Beacon with signed data', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        await updateBeacon(roles, api3ServerV1, beacon, 1, 1);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const signature = await testUtils.signOevData(
-                          api3ServerV1,
-                          oevProxy.address,
-                          beacon.beaconId,
-                          updateId,
-                          oevUpdateTimestamp,
-                          encodeData(oevUpdateValue),
-                          roles.searcher.address,
-                          bidAmount,
-                          beacon.airnode.wallet,
-                          beacon.templateId
-                        );
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          signature
-                        );
-                        const beaconBefore = await api3ServerV1.dataFeeds(beacon.beaconId);
-                        expect(beaconBefore.value).to.equal(1);
-                        expect(beaconBefore.timestamp).to.equal(1);
-                        const oevProxyBeaconBefore = await api3ServerV1.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beacon.beaconId
-                        );
-                        expect(oevProxyBeaconBefore.value).to.equal(0);
-                        expect(oevProxyBeaconBefore.timestamp).to.equal(0);
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        )
-                          .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconWithSignedData')
-                          .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
-                        const beaconAfter = await api3ServerV1.dataFeeds(beacon.beaconId);
-                        expect(beaconAfter.value).to.equal(1);
-                        expect(beaconAfter.timestamp).to.equal(1);
-                        const oevProxyBeaconAfter = await api3ServerV1.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beacon.beaconId
-                        );
-                        expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
-                        expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
-                      });
-                    });
-                    context('Data in the packed signature is not consistent with the data feed ID', function () {
-                      it('reverts', async function () {
-                        const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        const spoofedDataFeedId = beacons[1].beaconId;
-                        await updateBeacon(roles, api3ServerV1, beacons[1], 1, 1);
-                        await updateBeacon(roles, api3ServerV1, beacon, 1, 1);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const signature = await testUtils.signOevData(
-                          api3ServerV1,
-                          oevProxy.address,
-                          spoofedDataFeedId,
-                          updateId,
-                          oevUpdateTimestamp,
-                          encodeData(oevUpdateValue),
-                          roles.searcher.address,
-                          bidAmount,
-                          beacon.airnode.wallet,
-                          beacon.templateId
-                        );
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          signature
-                        );
-                        await expect(
-                          api3ServerV1
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              spoofedDataFeedId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Beacon ID mismatch');
-                      });
-                    });
+              context('There are invalid signatures', function () {
+                it('reverts', async function () {
+                  const { roles, api3ServerV1, oevProxy, beacons, beaconSet } = await deploy();
+                  const oevUpdateValue = 105;
+                  const currentTimestamp = await helpers.time.latest();
+                  const oevUpdateTimestamp = currentTimestamp + 1;
+                  const bidAmount = 10000;
+                  const updateId = testUtils.generateRandomBytes32();
+                  // Randomly omit one of the signatures
+                  const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                  const signatures = await Promise.all(
+                    beacons.map(async (beacon, index) => {
+                      if (index === omitSignatureAtIndex) {
+                        return '0x';
+                      } else {
+                        return '0x123456';
+                      }
+                    })
+                  );
+                  const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                    return packOevUpdateSignature(
+                      beacons[index].airnode.wallet.address,
+                      beacons[index].templateId,
+                      signature
+                    );
                   });
-                  context('The signature is omitted', function () {
-                    it('reverts', async function () {
+                  await expect(
+                    api3ServerV1
+                      .connect(roles.searcher)
+                      .updateOevProxyDataFeedWithSignedData(
+                        oevProxy.address,
+                        beaconSet.beaconSetId,
+                        updateId,
+                        oevUpdateTimestamp,
+                        encodeData(oevUpdateValue),
+                        packedOevUpdateSignatures,
+                        { value: bidAmount }
+                      )
+                  ).to.be.revertedWith('ECDSA: invalid signature length');
+                });
+              });
+            });
+            context('One Beacon is specified', function () {
+              context('The signature is not invalid', function () {
+                context('The signature is not omitted', function () {
+                  context('Data in the packed signature is consistent with the data feed ID', function () {
+                    it('updates OEV proxy Beacon with signed data', async function () {
                       const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
                       const beacon = beacons[0];
-                      await updateBeacon(roles, api3ServerV1, beacon, 1, 1);
-                      const oevUpdateValue = 0;
+                      const oevUpdateValue = 105;
                       const currentTimestamp = await helpers.time.latest();
                       const oevUpdateTimestamp = currentTimestamp + 1;
                       const bidAmount = 10000;
                       const updateId = testUtils.generateRandomBytes32();
+                      const signature = await testUtils.signOevData(
+                        api3ServerV1,
+                        oevProxy.address,
+                        beacon.beaconId,
+                        updateId,
+                        oevUpdateTimestamp,
+                        encodeData(oevUpdateValue),
+                        roles.searcher.address,
+                        bidAmount,
+                        beacon.airnode.wallet,
+                        beacon.templateId
+                      );
                       const packedOevUpdateSignature = packOevUpdateSignature(
                         beacon.airnode.wallet.address,
                         beacon.templateId,
-                        '0x'
+                        signature
                       );
+                      const beaconBefore = await api3ServerV1.dataFeeds(beacon.beaconId);
+                      expect(beaconBefore.value).to.equal(0);
+                      expect(beaconBefore.timestamp).to.equal(0);
+                      const oevProxyBeaconBefore = await api3ServerV1.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beacon.beaconId
+                      );
+                      expect(oevProxyBeaconBefore.value).to.equal(0);
+                      expect(oevProxyBeaconBefore.timestamp).to.equal(0);
                       await expect(
                         api3ServerV1
                           .connect(roles.searcher)
@@ -2201,16 +810,77 @@ describe('Api3ServerV1', function () {
                             [packedOevUpdateSignature],
                             { value: bidAmount }
                           )
-                      ).to.be.revertedWith('Missing signature');
+                      )
+                        .to.emit(api3ServerV1, 'UpdatedOevProxyBeaconWithSignedData')
+                        .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
+                      const beaconAfter = await api3ServerV1.dataFeeds(beacon.beaconId);
+                      expect(beaconAfter.value).to.equal(0);
+                      expect(beaconAfter.timestamp).to.equal(0);
+                      const oevProxyBeaconAfter = await api3ServerV1.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beacon.beaconId
+                      );
+                      expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
+                      expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
+                    });
+                  });
+                  context('Data in the packed signature is not consistent with the data feed ID', function () {
+                    it('reverts', async function () {
+                      const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
+                      const beacon = beacons[0];
+                      const oevUpdateValue = 105;
+                      const currentTimestamp = await helpers.time.latest();
+                      const oevUpdateTimestamp = currentTimestamp + 1;
+                      const bidAmount = 10000;
+                      const updateId = testUtils.generateRandomBytes32();
+                      const spoofedDataFeedId = testUtils.generateRandomBytes32();
+                      const signature = await testUtils.signOevData(
+                        api3ServerV1,
+                        oevProxy.address,
+                        spoofedDataFeedId,
+                        updateId,
+                        oevUpdateTimestamp,
+                        encodeData(oevUpdateValue),
+                        roles.searcher.address,
+                        bidAmount,
+                        beacon.airnode.wallet,
+                        beacon.templateId
+                      );
+                      const packedOevUpdateSignature = packOevUpdateSignature(
+                        beacon.airnode.wallet.address,
+                        beacon.templateId,
+                        signature
+                      );
+                      const beaconBefore = await api3ServerV1.dataFeeds(beacon.beaconId);
+                      expect(beaconBefore.value).to.equal(0);
+                      expect(beaconBefore.timestamp).to.equal(0);
+                      const oevProxyBeaconBefore = await api3ServerV1.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beacon.beaconId
+                      );
+                      expect(oevProxyBeaconBefore.value).to.equal(0);
+                      expect(oevProxyBeaconBefore.timestamp).to.equal(0);
+                      await expect(
+                        api3ServerV1
+                          .connect(roles.searcher)
+                          .updateOevProxyDataFeedWithSignedData(
+                            oevProxy.address,
+                            spoofedDataFeedId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            [packedOevUpdateSignature],
+                            { value: bidAmount }
+                          )
+                      ).to.be.revertedWith('Beacon ID mismatch');
                     });
                   });
                 });
-                context('The signature is invalid', function () {
+                context('The signature is omitted', function () {
                   it('reverts', async function () {
                     const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
                     const beacon = beacons[0];
-                    await updateBeacon(roles, api3ServerV1, beacon, 1, 1);
-                    const oevUpdateValue = 0;
+                    const oevUpdateValue = 105;
                     const currentTimestamp = await helpers.time.latest();
                     const oevUpdateTimestamp = currentTimestamp + 1;
                     const bidAmount = 10000;
@@ -2218,7 +888,7 @@ describe('Api3ServerV1', function () {
                     const packedOevUpdateSignature = packOevUpdateSignature(
                       beacon.airnode.wallet.address,
                       beacon.templateId,
-                      '0x123456'
+                      '0x'
                     );
                     await expect(
                       api3ServerV1
@@ -2232,20 +902,24 @@ describe('Api3ServerV1', function () {
                           [packedOevUpdateSignature],
                           { value: bidAmount }
                         )
-                    ).to.be.revertedWith('ECDSA: invalid signature length');
+                    ).to.be.revertedWith('Missing signature');
                   });
                 });
               });
-              context('No Beacon is specified', function () {
+              context('The signature is invalid', function () {
                 it('reverts', async function () {
                   const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
                   const beacon = beacons[0];
-                  await updateBeacon(roles, api3ServerV1, beacon, 1, 1);
-                  const oevUpdateValue = 0;
+                  const oevUpdateValue = 105;
                   const currentTimestamp = await helpers.time.latest();
                   const oevUpdateTimestamp = currentTimestamp + 1;
                   const bidAmount = 10000;
                   const updateId = testUtils.generateRandomBytes32();
+                  const packedOevUpdateSignature = packOevUpdateSignature(
+                    beacon.airnode.wallet.address,
+                    beacon.templateId,
+                    '0x123456'
+                  );
                   await expect(
                     api3ServerV1
                       .connect(roles.searcher)
@@ -2255,18 +929,18 @@ describe('Api3ServerV1', function () {
                         updateId,
                         oevUpdateTimestamp,
                         encodeData(oevUpdateValue),
-                        [],
+                        [packedOevUpdateSignature],
                         { value: bidAmount }
                       )
-                  ).to.be.revertedWith('Did not specify any Beacons');
+                  ).to.be.revertedWith('ECDSA: invalid signature length');
                 });
               });
             });
-            context('Updated value same as base feed value', function () {
+            context('No Beacon is specified', function () {
               it('reverts', async function () {
                 const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
                 const beacon = beacons[0];
-                const oevUpdateValue = 0;
+                const oevUpdateValue = 105;
                 const currentTimestamp = await helpers.time.latest();
                 const oevUpdateTimestamp = currentTimestamp + 1;
                 const bidAmount = 10000;
@@ -2283,47 +957,36 @@ describe('Api3ServerV1', function () {
                       [],
                       { value: bidAmount }
                     )
-                ).to.be.revertedWith('Repeats base feed update');
+                ).to.be.revertedWith('Did not specify any Beacons');
               });
             });
           });
-          context('Does not update timestamp', function () {
+          context('Decoded fulfillment data cannot be typecasted into int224', function () {
             it('reverts', async function () {
               const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
               const beacon = beacons[0];
-              const oevUpdateValue = 105;
+              const oevUpdateValueWithUnderflow = ethers.BigNumber.from(-2).pow(223).sub(1);
               const currentTimestamp = await helpers.time.latest();
               const oevUpdateTimestamp = currentTimestamp + 1;
               const bidAmount = 10000;
               const updateId = testUtils.generateRandomBytes32();
-              const signature = await testUtils.signOevData(
+              const signatureWithUnderflow = await testUtils.signOevData(
                 api3ServerV1,
                 oevProxy.address,
                 beacon.beaconId,
                 updateId,
                 oevUpdateTimestamp,
-                encodeData(oevUpdateValue),
+                encodeData(oevUpdateValueWithUnderflow),
                 roles.searcher.address,
                 bidAmount,
                 beacon.airnode.wallet,
                 beacon.templateId
               );
-              const packedOevUpdateSignature = packOevUpdateSignature(
+              const packedOevUpdateSignatureWithUnderflow = packOevUpdateSignature(
                 beacon.airnode.wallet.address,
                 beacon.templateId,
-                signature
+                signatureWithUnderflow
               );
-              await api3ServerV1
-                .connect(roles.searcher)
-                .updateOevProxyDataFeedWithSignedData(
-                  oevProxy.address,
-                  beacon.beaconId,
-                  updateId,
-                  oevUpdateTimestamp,
-                  encodeData(oevUpdateValue),
-                  [packedOevUpdateSignature],
-                  { value: bidAmount }
-                );
               await expect(
                 api3ServerV1
                   .connect(roles.searcher)
@@ -2332,39 +995,70 @@ describe('Api3ServerV1', function () {
                     beacon.beaconId,
                     updateId,
                     oevUpdateTimestamp,
-                    encodeData(oevUpdateValue),
-                    [packedOevUpdateSignature],
+                    encodeData(oevUpdateValueWithUnderflow),
+                    [packedOevUpdateSignatureWithUnderflow],
                     { value: bidAmount }
                   )
-              ).to.be.revertedWith('Does not update timestamp');
+              ).to.be.revertedWith('Value typecasting error');
+              const oevUpdateValueWithOverflow = ethers.BigNumber.from(2).pow(223);
+              const signatureWithOverflow = await testUtils.signOevData(
+                api3ServerV1,
+                oevProxy.address,
+                beacon.beaconId,
+                updateId,
+                oevUpdateTimestamp,
+                encodeData(oevUpdateValueWithOverflow),
+                roles.searcher.address,
+                bidAmount,
+                beacon.airnode.wallet,
+                beacon.templateId
+              );
+              const packedOevUpdateSignatureWithOverflow = packOevUpdateSignature(
+                beacon.airnode.wallet.address,
+                beacon.templateId,
+                signatureWithOverflow
+              );
+              await expect(
+                api3ServerV1
+                  .connect(roles.searcher)
+                  .updateOevProxyDataFeedWithSignedData(
+                    oevProxy.address,
+                    beacon.beaconId,
+                    updateId,
+                    oevUpdateTimestamp,
+                    encodeData(oevUpdateValueWithOverflow),
+                    [packedOevUpdateSignatureWithOverflow],
+                    { value: bidAmount }
+                  )
+              ).to.be.revertedWith('Value typecasting error');
             });
           });
         });
-        context('Decoded fulfillment data cannot be typecasted into int224', function () {
+        context('Fulfillment data length is not correct', function () {
           it('reverts', async function () {
             const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
             const beacon = beacons[0];
-            const oevUpdateValueWithUnderflow = ethers.BigNumber.from(-2).pow(223).sub(1);
+            const oevUpdateValue = 105;
             const currentTimestamp = await helpers.time.latest();
             const oevUpdateTimestamp = currentTimestamp + 1;
             const bidAmount = 10000;
             const updateId = testUtils.generateRandomBytes32();
-            const signatureWithUnderflow = await testUtils.signOevData(
+            const signature = await testUtils.signOevData(
               api3ServerV1,
               oevProxy.address,
               beacon.beaconId,
               updateId,
               oevUpdateTimestamp,
-              encodeData(oevUpdateValueWithUnderflow),
+              encodeData(oevUpdateValue) + '00',
               roles.searcher.address,
               bidAmount,
               beacon.airnode.wallet,
               beacon.templateId
             );
-            const packedOevUpdateSignatureWithUnderflow = packOevUpdateSignature(
+            const packedOevUpdateSignature = packOevUpdateSignature(
               beacon.airnode.wallet.address,
               beacon.templateId,
-              signatureWithUnderflow
+              signature
             );
             await expect(
               api3ServerV1
@@ -2374,46 +1068,15 @@ describe('Api3ServerV1', function () {
                   beacon.beaconId,
                   updateId,
                   oevUpdateTimestamp,
-                  encodeData(oevUpdateValueWithUnderflow),
-                  [packedOevUpdateSignatureWithUnderflow],
+                  encodeData(oevUpdateValue) + '00',
+                  [packedOevUpdateSignature],
                   { value: bidAmount }
                 )
-            ).to.be.revertedWith('Value typecasting error');
-            const oevUpdateValueWithOverflow = ethers.BigNumber.from(2).pow(223);
-            const signatureWithOverflow = await testUtils.signOevData(
-              api3ServerV1,
-              oevProxy.address,
-              beacon.beaconId,
-              updateId,
-              oevUpdateTimestamp,
-              encodeData(oevUpdateValueWithOverflow),
-              roles.searcher.address,
-              bidAmount,
-              beacon.airnode.wallet,
-              beacon.templateId
-            );
-            const packedOevUpdateSignatureWithOverflow = packOevUpdateSignature(
-              beacon.airnode.wallet.address,
-              beacon.templateId,
-              signatureWithOverflow
-            );
-            await expect(
-              api3ServerV1
-                .connect(roles.searcher)
-                .updateOevProxyDataFeedWithSignedData(
-                  oevProxy.address,
-                  beacon.beaconId,
-                  updateId,
-                  oevUpdateTimestamp,
-                  encodeData(oevUpdateValueWithOverflow),
-                  [packedOevUpdateSignatureWithOverflow],
-                  { value: bidAmount }
-                )
-            ).to.be.revertedWith('Value typecasting error');
+            ).to.be.revertedWith('Data length not correct');
           });
         });
       });
-      context('Fulfillment data length is not correct', function () {
+      context('Does not update timestamp', function () {
         it('reverts', async function () {
           const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
           const beacon = beacons[0];
@@ -2428,7 +1091,7 @@ describe('Api3ServerV1', function () {
             beacon.beaconId,
             updateId,
             oevUpdateTimestamp,
-            encodeData(oevUpdateValue) + '00',
+            encodeData(oevUpdateValue),
             roles.searcher.address,
             bidAmount,
             beacon.airnode.wallet,
@@ -2439,6 +1102,17 @@ describe('Api3ServerV1', function () {
             beacon.templateId,
             signature
           );
+          await api3ServerV1
+            .connect(roles.searcher)
+            .updateOevProxyDataFeedWithSignedData(
+              oevProxy.address,
+              beacon.beaconId,
+              updateId,
+              oevUpdateTimestamp,
+              encodeData(oevUpdateValue),
+              [packedOevUpdateSignature],
+              { value: bidAmount }
+            );
           await expect(
             api3ServerV1
               .connect(roles.searcher)
@@ -2447,11 +1121,11 @@ describe('Api3ServerV1', function () {
                 beacon.beaconId,
                 updateId,
                 oevUpdateTimestamp,
-                encodeData(oevUpdateValue) + '00',
+                encodeData(oevUpdateValue),
                 [packedOevUpdateSignature],
                 { value: bidAmount }
               )
-          ).to.be.revertedWith('Data length not correct');
+          ).to.be.revertedWith('Does not update timestamp');
         });
       });
     });
@@ -2480,6 +1154,20 @@ describe('Api3ServerV1', function () {
         ).to.be.revertedWith('Timestamp not valid');
       });
     });
+    context('Timestamp is zero', function () {
+      it('reverts', async function () {
+        const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
+        const bidAmount = 10000;
+        const updateId = testUtils.generateRandomBytes32();
+        await expect(
+          api3ServerV1
+            .connect(roles.searcher)
+            .updateOevProxyDataFeedWithSignedData(oevProxy.address, updateId, beacons[0].beaconId, 0, '0x', ['0x'], {
+              value: bidAmount,
+            })
+        ).to.be.revertedWith('Does not update timestamp');
+      });
+    });
   });
 
   describe('withdraw', function () {
@@ -2490,7 +1178,7 @@ describe('Api3ServerV1', function () {
             it('withdraws the OEV proxy balance to the respective beneficiary', async function () {
               const { roles, api3ServerV1, oevProxy, beacons } = await deploy();
               const beacon = beacons[0];
-              const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+              const beaconValue = Math.floor(Math.random() * 200 - 100);
               const beaconTimestamp = await helpers.time.latest();
               const bidAmount = 10000;
               const updateId = testUtils.generateRandomBytes32();
@@ -2551,7 +1239,7 @@ describe('Api3ServerV1', function () {
                 beacon.beaconId,
                 api3ServerV1.address
               );
-              const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+              const beaconValue = Math.floor(Math.random() * 200 - 100);
               const beaconTimestamp = await helpers.time.latest();
               const bidAmount = 10000;
               const updateId = testUtils.generateRandomBytes32();
@@ -2719,7 +1407,7 @@ describe('Api3ServerV1', function () {
       it('reads data feed', async function () {
         const { roles, api3ServerV1, beacons } = await deploy();
         const beacon = beacons[0];
-        const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+        const beaconValue = Math.floor(Math.random() * 200 - 100);
         const beaconTimestamp = await helpers.time.latest();
         await updateBeacon(roles, api3ServerV1, beacon, beaconValue, beaconTimestamp);
         const beaconAfter = await api3ServerV1.connect(roles.randomPerson).readDataFeedWithId(beacon.beaconId);
@@ -2744,7 +1432,7 @@ describe('Api3ServerV1', function () {
         it('reads Beacon', async function () {
           const { roles, api3ServerV1, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           await updateBeacon(roles, api3ServerV1, beacon, beaconValue, beaconTimestamp);
           const dapiName = ethers.utils.formatBytes32String('My dAPI');
@@ -2772,7 +1460,7 @@ describe('Api3ServerV1', function () {
       context('Data feed is initialized', function () {
         it('reads Beacon set', async function () {
           const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
-          const beaconSetValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconSetValue = Math.floor(Math.random() * 200 - 100);
           const beaconSetTimestamp = await helpers.time.latest();
           await updateBeaconSet(roles, api3ServerV1, beacons, beaconSetValue, beaconSetTimestamp);
           const dapiName = ethers.utils.formatBytes32String('My dAPI');
@@ -2813,7 +1501,7 @@ describe('Api3ServerV1', function () {
         it('reads OEV proxy data feed', async function () {
           const { roles, api3ServerV1, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           const bidAmount = 10000;
           const updateId = testUtils.generateRandomBytes32();
@@ -2858,7 +1546,7 @@ describe('Api3ServerV1', function () {
         it('reads base data feed', async function () {
           const { roles, api3ServerV1, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           await updateBeacon(roles, api3ServerV1, beacon, beaconValue, beaconTimestamp);
           const beaconAfter = await api3ServerV1
@@ -2887,7 +1575,7 @@ describe('Api3ServerV1', function () {
           it('reads OEV proxy data feed', async function () {
             const { roles, api3ServerV1, beacons } = await deploy();
             const beacon = beacons[0];
-            const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconValue = Math.floor(Math.random() * 200 - 100);
             const beaconTimestamp = await helpers.time.latest();
             const bidAmount = 10000;
             const updateId = testUtils.generateRandomBytes32();
@@ -2935,7 +1623,7 @@ describe('Api3ServerV1', function () {
           it('reads base data feed', async function () {
             const { roles, api3ServerV1, beacons } = await deploy();
             const beacon = beacons[0];
-            const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconValue = Math.floor(Math.random() * 200 - 100);
             const beaconTimestamp = await helpers.time.latest();
             await updateBeacon(roles, api3ServerV1, beacon, beaconValue, beaconTimestamp);
             const dapiName = ethers.utils.formatBytes32String('My dAPI');
@@ -3039,7 +1727,7 @@ describe('Api3ServerV1', function () {
           it('reads base data feed', async function () {
             const { roles, api3ServerV1, beacons, beaconSet } = await deploy();
             const currentTimestamp = await helpers.time.latest();
-            const beaconSetValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconSetValue = Math.floor(Math.random() * 200 - 100);
             const beaconSetTimestamp = Math.floor(currentTimestamp - Math.random() * 5 * 60);
             await updateBeaconSet(roles, api3ServerV1, beacons, beaconSetValue, beaconSetTimestamp);
             const dapiName = ethers.utils.formatBytes32String('My dAPI');

--- a/test/dapis/DataFeedServerFull.sol.js
+++ b/test/dapis/DataFeedServerFull.sol.js
@@ -58,49 +58,6 @@ describe('DataFeedServerFull', function () {
     ];
     await dataFeedServerFull.connect(roles.randomPerson).multicall(updateBeaconSetCalldata);
   }
-  async function updateProxyDataFeed(
-    roles,
-    dataFeedServerFull,
-    oevProxyAddress,
-    beacons,
-    updateId,
-    dataFeedId,
-    decodedData,
-    timestamp
-  ) {
-    if (!timestamp) {
-      timestamp = await helpers.time.latest();
-    }
-    const data = encodeData(decodedData);
-    const packedOevUpdateSignatures = await Promise.all(
-      beacons.map(async (beacon) => {
-        const signature = await testUtils.signOevData(
-          dataFeedServerFull,
-          oevProxyAddress,
-          dataFeedId,
-          updateId,
-          timestamp,
-          data,
-          roles.searcher.address,
-          1,
-          beacon.airnode.wallet,
-          beacon.templateId
-        );
-        return packOevUpdateSignature(beacon.airnode.wallet.address, beacon.templateId, signature);
-      })
-    );
-    await dataFeedServerFull
-      .connect(roles.searcher)
-      .updateOevProxyDataFeedWithSignedData(
-        oevProxyAddress,
-        dataFeedId,
-        updateId,
-        timestamp,
-        data,
-        packedOevUpdateSignatures,
-        { value: 1 }
-      );
-  }
 
   function encodeUpdateSubscriptionConditionParameters(
     deviationThresholdInPercentage,
@@ -884,121 +841,9 @@ describe('DataFeedServerFull', function () {
       context('Timestamp is valid', function () {
         context('Encoded data length is correct', function () {
           context('Data is typecast successfully', function () {
-            context('Updates timestamp', function () {
-              context('Updates value', function () {
-                context('Request is regular', function () {
-                  it('updates Beacon', async function () {
-                    const { roles, airnodeProtocol, dataFeedServerFull, beacons } = await deploy();
-                    const beacon = beacons[0];
-                    const requestId = await testUtils.deriveRequestId(
-                      airnodeProtocol,
-                      dataFeedServerFull.address,
-                      beacon.airnode.wallet.address,
-                      beacon.templateId,
-                      '0x',
-                      roles.sponsor.address,
-                      dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate')
-                    );
-                    await dataFeedServerFull
-                      .connect(roles.sponsor)
-                      .requestRrpBeaconUpdateWithTemplate(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        roles.sponsor.address
-                      );
-                    const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                    expect(beaconBefore.value).to.equal(0);
-                    expect(beaconBefore.timestamp).to.equal(0);
-                    const decodedData = 123;
-                    const data = encodeData(decodedData);
-                    const timestamp = await helpers.time.latest();
-                    const signature = testUtils.signRrpFulfillment(
-                      beacon.airnode.wallet,
-                      requestId,
-                      timestamp,
-                      beacon.airnode.rrpSponsorWallet.address
-                    );
-                    await expect(
-                      airnodeProtocol
-                        .connect(beacon.airnode.rrpSponsorWallet)
-                        .fulfillRequest(
-                          requestId,
-                          beacon.airnode.wallet.address,
-                          dataFeedServerFull.address,
-                          dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate'),
-                          timestamp,
-                          data,
-                          signature,
-                          { gasLimit: 500000 }
-                        )
-                    )
-                      .to.emit(dataFeedServerFull, 'UpdatedBeaconWithRrp')
-                      .withArgs(beacon.beaconId, requestId, decodedData, timestamp);
-                    const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                    expect(beaconAfter.value).to.equal(decodedData);
-                    expect(beaconAfter.timestamp).to.equal(timestamp);
-                  });
-                });
-                context('Request is relayed', function () {
-                  it('updates Beacon', async function () {
-                    const { roles, airnodeProtocol, dataFeedServerFull, beacons } = await helpers.loadFixture(deploy);
-                    const beacon = beacons[0];
-                    const requestId = await testUtils.deriveRelayedRequestId(
-                      airnodeProtocol,
-                      dataFeedServerFull.address,
-                      beacon.airnode.wallet.address,
-                      beacon.templateId,
-                      '0x',
-                      beacon.relayer.wallet.address,
-                      roles.sponsor.address,
-                      dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate')
-                    );
-                    await dataFeedServerFull
-                      .connect(roles.sponsor)
-                      .requestRelayedRrpBeaconUpdateWithTemplate(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.relayer.wallet.address,
-                        roles.sponsor.address
-                      );
-                    const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                    expect(beaconBefore.value).to.equal(0);
-                    expect(beaconBefore.timestamp).to.equal(0);
-                    const decodedData = 123;
-                    const data = encodeData(decodedData);
-                    const timestamp = await helpers.time.latest();
-                    const signature = testUtils.signRrpRelayedFulfillment(
-                      beacon.airnode.wallet,
-                      requestId,
-                      timestamp,
-                      beacon.relayer.rrpRelayedSponsorWallet.address,
-                      data
-                    );
-                    await expect(
-                      airnodeProtocol
-                        .connect(beacon.relayer.rrpRelayedSponsorWallet)
-                        .fulfillRequestRelayed(
-                          requestId,
-                          beacon.airnode.wallet.address,
-                          dataFeedServerFull.address,
-                          beacon.relayer.wallet.address,
-                          dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate'),
-                          timestamp,
-                          data,
-                          signature,
-                          { gasLimit: 500000 }
-                        )
-                    )
-                      .to.emit(dataFeedServerFull, 'UpdatedBeaconWithRrp')
-                      .withArgs(beacon.beaconId, requestId, decodedData, timestamp);
-                    const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                    expect(beaconAfter.value).to.equal(decodedData);
-                    expect(beaconAfter.timestamp).to.equal(timestamp);
-                  });
-                });
-              });
-              context('Does not update value', function () {
-                it('does not update Beacon', async function () {
+            context('Data is fresher than Beacon', function () {
+              context('Request is regular', function () {
+                it('updates Beacon', async function () {
                   const { roles, airnodeProtocol, dataFeedServerFull, beacons } = await deploy();
                   const beacon = beacons[0];
                   const requestId = await testUtils.deriveRequestId(
@@ -1020,31 +865,15 @@ describe('DataFeedServerFull', function () {
                   const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
                   expect(beaconBefore.value).to.equal(0);
                   expect(beaconBefore.timestamp).to.equal(0);
-                  const updatedTimestamp = (await helpers.time.latest()) - 10 * 60;
-                  const updatedDecodedData = 456;
-                  await updateBeacon(roles, dataFeedServerFull, beacon, updatedDecodedData, updatedTimestamp);
-                  const data = encodeData(updatedDecodedData);
-                  const timestampSecond = updatedTimestamp + 1;
-                  const signatureSecond = testUtils.signRrpFulfillment(
+                  const decodedData = 123;
+                  const data = encodeData(decodedData);
+                  const timestamp = await helpers.time.latest();
+                  const signature = testUtils.signRrpFulfillment(
                     beacon.airnode.wallet,
                     requestId,
-                    timestampSecond,
+                    timestamp,
                     beacon.airnode.rrpSponsorWallet.address
                   );
-                  const staticCallResult = await airnodeProtocol
-                    .connect(beacon.airnode.rrpSponsorWallet)
-                    .callStatic.fulfillRequest(
-                      requestId,
-                      beacon.airnode.wallet.address,
-                      dataFeedServerFull.address,
-                      dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate'),
-                      timestampSecond,
-                      data,
-                      signatureSecond,
-                      { gasLimit: 500000 }
-                    );
-                  expect(staticCallResult.callSuccess).to.equal(false);
-                  expect(testUtils.decodeRevertString(staticCallResult.callData)).to.equal('Does not update value');
                   await expect(
                     airnodeProtocol
                       .connect(beacon.airnode.rrpSponsorWallet)
@@ -1053,19 +882,78 @@ describe('DataFeedServerFull', function () {
                         beacon.airnode.wallet.address,
                         dataFeedServerFull.address,
                         dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate'),
-                        timestampSecond,
+                        timestamp,
                         data,
-                        signatureSecond,
+                        signature,
                         { gasLimit: 500000 }
                       )
-                  ).to.not.emit(dataFeedServerFull, 'UpdatedBeaconWithRrp');
+                  )
+                    .to.emit(dataFeedServerFull, 'UpdatedBeaconWithRrp')
+                    .withArgs(beacon.beaconId, requestId, decodedData, timestamp);
                   const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                  expect(beaconAfter.value).to.equal(updatedDecodedData);
-                  expect(beaconAfter.timestamp).to.equal(updatedTimestamp);
+                  expect(beaconAfter.value).to.equal(decodedData);
+                  expect(beaconAfter.timestamp).to.equal(timestamp);
+                });
+              });
+              context('Request is relayed', function () {
+                it('updates Beacon', async function () {
+                  const { roles, airnodeProtocol, dataFeedServerFull, beacons } = await helpers.loadFixture(deploy);
+                  const beacon = beacons[0];
+                  const requestId = await testUtils.deriveRelayedRequestId(
+                    airnodeProtocol,
+                    dataFeedServerFull.address,
+                    beacon.airnode.wallet.address,
+                    beacon.templateId,
+                    '0x',
+                    beacon.relayer.wallet.address,
+                    roles.sponsor.address,
+                    dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate')
+                  );
+                  await dataFeedServerFull
+                    .connect(roles.sponsor)
+                    .requestRelayedRrpBeaconUpdateWithTemplate(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.relayer.wallet.address,
+                      roles.sponsor.address
+                    );
+                  const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                  expect(beaconBefore.value).to.equal(0);
+                  expect(beaconBefore.timestamp).to.equal(0);
+                  const decodedData = 123;
+                  const data = encodeData(decodedData);
+                  const timestamp = await helpers.time.latest();
+                  const signature = testUtils.signRrpRelayedFulfillment(
+                    beacon.airnode.wallet,
+                    requestId,
+                    timestamp,
+                    beacon.relayer.rrpRelayedSponsorWallet.address,
+                    data
+                  );
+                  await expect(
+                    airnodeProtocol
+                      .connect(beacon.relayer.rrpRelayedSponsorWallet)
+                      .fulfillRequestRelayed(
+                        requestId,
+                        beacon.airnode.wallet.address,
+                        dataFeedServerFull.address,
+                        beacon.relayer.wallet.address,
+                        dataFeedServerFull.interface.getSighash('fulfillRrpBeaconUpdate'),
+                        timestamp,
+                        data,
+                        signature,
+                        { gasLimit: 500000 }
+                      )
+                  )
+                    .to.emit(dataFeedServerFull, 'UpdatedBeaconWithRrp')
+                    .withArgs(beacon.beaconId, requestId, decodedData, timestamp);
+                  const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                  expect(beaconAfter.value).to.equal(decodedData);
+                  expect(beaconAfter.timestamp).to.equal(timestamp);
                 });
               });
             });
-            context('Does not update timestamp', function () {
+            context('Data is not fresher than Beacon', function () {
               it('does not update Beacon', async function () {
                 const { roles, airnodeProtocol, dataFeedServerFull, beacons } = await deploy();
                 const beacon = beacons[0];
@@ -2086,251 +1974,200 @@ describe('DataFeedServerFull', function () {
     context('Timestamp is valid', function () {
       context('Subscription is registered', function () {
         context('Data length is correct', function () {
-          context('Updates timestamp', function () {
-            context('Updates value', function () {
-              context('Subscription is regular', function () {
-                context('Signature is valid', function () {
-                  it('updates Beacon', async function () {
-                    const { roles, dataFeedServerFull, beacons } = await deploy();
-                    const beacon = beacons[0];
-                    const subscriptionId = await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .callStatic.registerBeaconUpdateSubscription(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
-                        beacon.airnode.wallet.address,
-                        roles.sponsor.address
-                      );
-                    await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .registerBeaconUpdateSubscription(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
-                        beacon.airnode.wallet.address,
-                        roles.sponsor.address
-                      );
-                    const decodedData = 123;
-                    const data = encodeData(decodedData);
-                    const timestamp = await helpers.time.latest();
-                    const signature = testUtils.signPspFulfillment(
-                      beacon.airnode.wallet,
-                      subscriptionId,
-                      timestamp,
-                      beacon.airnode.pspSponsorWallet.address
+          context('Data is fresher than Beacon', function () {
+            context('Subscription is regular', function () {
+              context('Signature is valid', function () {
+                it('updates Beacon', async function () {
+                  const { roles, dataFeedServerFull, beacons } = await deploy();
+                  const beacon = beacons[0];
+                  const subscriptionId = await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .callStatic.registerBeaconUpdateSubscription(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.airnode.wallet.address,
+                      roles.sponsor.address
                     );
-                    await expect(
-                      dataFeedServerFull
-                        .connect(beacon.airnode.pspSponsorWallet)
-                        .fulfillPspBeaconUpdate(
-                          subscriptionId,
-                          beacon.airnode.wallet.address,
-                          beacon.airnode.wallet.address,
-                          roles.sponsor.address,
-                          timestamp,
-                          data,
-                          signature,
-                          { gasLimit: 500000 }
-                        )
-                    )
-                      .to.emit(dataFeedServerFull, 'UpdatedBeaconWithPsp')
-                      .withArgs(beacon.beaconId, subscriptionId, decodedData, timestamp);
-                    const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                    expect(beaconAfter.value).to.equal(decodedData);
-                    expect(beaconAfter.timestamp).to.equal(timestamp);
-                  });
-                });
-                context('Signature is not valid', function () {
-                  it('reverts', async function () {
-                    const { roles, dataFeedServerFull, beacons } = await deploy();
-                    const beacon = beacons[0];
-                    const subscriptionId = await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .callStatic.registerBeaconUpdateSubscription(
+                  await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .registerBeaconUpdateSubscription(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.airnode.wallet.address,
+                      roles.sponsor.address
+                    );
+                  const decodedData = 123;
+                  const data = encodeData(decodedData);
+                  const timestamp = await helpers.time.latest();
+                  const signature = testUtils.signPspFulfillment(
+                    beacon.airnode.wallet,
+                    subscriptionId,
+                    timestamp,
+                    beacon.airnode.pspSponsorWallet.address
+                  );
+                  await expect(
+                    dataFeedServerFull
+                      .connect(beacon.airnode.pspSponsorWallet)
+                      .fulfillPspBeaconUpdate(
+                        subscriptionId,
                         beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
                         beacon.airnode.wallet.address,
-                        roles.sponsor.address
-                      );
-                    await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .registerBeaconUpdateSubscription(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
-                        beacon.airnode.wallet.address,
-                        roles.sponsor.address
-                      );
-                    const decodedData = 123;
-                    const data = encodeData(decodedData);
-                    const timestamp = await helpers.time.latest();
-                    await expect(
-                      dataFeedServerFull
-                        .connect(beacon.airnode.pspSponsorWallet)
-                        .fulfillPspBeaconUpdate(
-                          subscriptionId,
-                          beacon.airnode.wallet.address,
-                          beacon.airnode.wallet.address,
-                          roles.sponsor.address,
-                          timestamp,
-                          data,
-                          '0x12345678',
-                          { gasLimit: 500000 }
-                        )
-                    ).to.be.revertedWith('ECDSA: invalid signature length');
-                  });
+                        roles.sponsor.address,
+                        timestamp,
+                        data,
+                        signature,
+                        { gasLimit: 500000 }
+                      )
+                  )
+                    .to.emit(dataFeedServerFull, 'UpdatedBeaconWithPsp')
+                    .withArgs(beacon.beaconId, subscriptionId, decodedData, timestamp);
+                  const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                  expect(beaconAfter.value).to.equal(decodedData);
+                  expect(beaconAfter.timestamp).to.equal(timestamp);
                 });
               });
-              context('Subscription is relayed', function () {
-                context('Signature is valid', function () {
-                  it('updates Beacon', async function () {
-                    const { roles, dataFeedServerFull, beacons } = await deploy();
-                    const beacon = beacons[0];
-                    const subscriptionId = await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .callStatic.registerBeaconUpdateSubscription(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
-                        beacon.relayer.wallet.address,
-                        roles.sponsor.address
-                      );
-                    await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .registerBeaconUpdateSubscription(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
-                        beacon.relayer.wallet.address,
-                        roles.sponsor.address
-                      );
-                    const decodedData = 123;
-                    const data = encodeData(decodedData);
-                    const timestamp = await helpers.time.latest();
-                    const signature = testUtils.signPspRelayedFulfillment(
-                      beacon.airnode.wallet,
-                      subscriptionId,
-                      timestamp,
-                      beacon.relayer.pspRelayedSponsorWallet.address,
-                      data
+              context('Signature is not valid', function () {
+                it('reverts', async function () {
+                  const { roles, dataFeedServerFull, beacons } = await deploy();
+                  const beacon = beacons[0];
+                  const subscriptionId = await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .callStatic.registerBeaconUpdateSubscription(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.airnode.wallet.address,
+                      roles.sponsor.address
                     );
-                    await expect(
-                      dataFeedServerFull
-                        .connect(beacon.relayer.pspRelayedSponsorWallet)
-                        .fulfillPspBeaconUpdate(
-                          subscriptionId,
-                          beacon.airnode.wallet.address,
-                          beacon.relayer.wallet.address,
-                          roles.sponsor.address,
-                          timestamp,
-                          data,
-                          signature,
-                          { gasLimit: 500000 }
-                        )
-                    )
-                      .to.emit(dataFeedServerFull, 'UpdatedBeaconWithPsp')
-                      .withArgs(beacon.beaconId, subscriptionId, decodedData, timestamp);
-                    const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                    expect(beaconAfter.value).to.equal(decodedData);
-                    expect(beaconAfter.timestamp).to.equal(timestamp);
-                  });
-                });
-                context('Signature is not valid', function () {
-                  it('reverts', async function () {
-                    const { roles, dataFeedServerFull, beacons } = await deploy();
-                    const beacon = beacons[0];
-                    const subscriptionId = await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .callStatic.registerBeaconUpdateSubscription(
+                  await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .registerBeaconUpdateSubscription(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.airnode.wallet.address,
+                      roles.sponsor.address
+                    );
+                  const decodedData = 123;
+                  const data = encodeData(decodedData);
+                  const timestamp = await helpers.time.latest();
+                  await expect(
+                    dataFeedServerFull
+                      .connect(beacon.airnode.pspSponsorWallet)
+                      .fulfillPspBeaconUpdate(
+                        subscriptionId,
                         beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
-                        beacon.relayer.wallet.address,
-                        roles.sponsor.address
-                      );
-                    await dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .registerBeaconUpdateSubscription(
                         beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beacon.beaconUpdateSubscriptionConditions,
-                        beacon.relayer.wallet.address,
-                        roles.sponsor.address
-                      );
-                    const decodedData = 123;
-                    const data = encodeData(decodedData);
-                    const timestamp = await helpers.time.latest();
-                    await expect(
-                      dataFeedServerFull
-                        .connect(beacon.relayer.pspRelayedSponsorWallet)
-                        .fulfillPspBeaconUpdate(
-                          subscriptionId,
-                          beacon.airnode.wallet.address,
-                          beacon.relayer.wallet.address,
-                          roles.sponsor.address,
-                          timestamp,
-                          data,
-                          '0x12345678',
-                          { gasLimit: 500000 }
-                        )
-                    ).to.be.revertedWith('ECDSA: invalid signature length');
-                  });
+                        roles.sponsor.address,
+                        timestamp,
+                        data,
+                        '0x12345678',
+                        { gasLimit: 500000 }
+                      )
+                  ).to.be.revertedWith('ECDSA: invalid signature length');
                 });
               });
             });
-            context('Does not update value', function () {
-              it('reverts', async function () {
-                const { roles, dataFeedServerFull, beacons } = await deploy();
-                const beacon = beacons[0];
-                const subscriptionId = await dataFeedServerFull
-                  .connect(roles.randomPerson)
-                  .callStatic.registerBeaconUpdateSubscription(
-                    beacon.airnode.wallet.address,
-                    beacon.templateId,
-                    beacon.beaconUpdateSubscriptionConditions,
-                    beacon.airnode.wallet.address,
-                    roles.sponsor.address
-                  );
-                await dataFeedServerFull
-                  .connect(roles.randomPerson)
-                  .registerBeaconUpdateSubscription(
-                    beacon.airnode.wallet.address,
-                    beacon.templateId,
-                    beacon.beaconUpdateSubscriptionConditions,
-                    beacon.airnode.wallet.address,
-                    roles.sponsor.address
-                  );
-                const updatedTimestamp = (await helpers.time.latest()) - 10 * 60;
-                const updatedDecodedData = 456;
-                await updateBeacon(roles, dataFeedServerFull, beacon, updatedDecodedData, updatedTimestamp);
-                const data = encodeData(updatedDecodedData);
-                const timestampSecond = updatedTimestamp + 1;
-                const signatureSecond = testUtils.signPspFulfillment(
-                  beacon.airnode.wallet,
-                  subscriptionId,
-                  timestampSecond,
-                  beacon.airnode.pspSponsorWallet.address
-                );
-                await expect(
-                  dataFeedServerFull
-                    .connect(beacon.airnode.pspSponsorWallet)
-                    .fulfillPspBeaconUpdate(
-                      subscriptionId,
+            context('Subscription is relayed', function () {
+              context('Signature is valid', function () {
+                it('updates Beacon', async function () {
+                  const { roles, dataFeedServerFull, beacons } = await deploy();
+                  const beacon = beacons[0];
+                  const subscriptionId = await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .callStatic.registerBeaconUpdateSubscription(
                       beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.relayer.wallet.address,
+                      roles.sponsor.address
+                    );
+                  await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .registerBeaconUpdateSubscription(
                       beacon.airnode.wallet.address,
-                      roles.sponsor.address,
-                      timestampSecond,
-                      data,
-                      signatureSecond,
-                      { gasLimit: 500000 }
-                    )
-                ).to.be.revertedWith('Does not update value');
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.relayer.wallet.address,
+                      roles.sponsor.address
+                    );
+                  const decodedData = 123;
+                  const data = encodeData(decodedData);
+                  const timestamp = await helpers.time.latest();
+                  const signature = testUtils.signPspRelayedFulfillment(
+                    beacon.airnode.wallet,
+                    subscriptionId,
+                    timestamp,
+                    beacon.relayer.pspRelayedSponsorWallet.address,
+                    data
+                  );
+                  await expect(
+                    dataFeedServerFull
+                      .connect(beacon.relayer.pspRelayedSponsorWallet)
+                      .fulfillPspBeaconUpdate(
+                        subscriptionId,
+                        beacon.airnode.wallet.address,
+                        beacon.relayer.wallet.address,
+                        roles.sponsor.address,
+                        timestamp,
+                        data,
+                        signature,
+                        { gasLimit: 500000 }
+                      )
+                  )
+                    .to.emit(dataFeedServerFull, 'UpdatedBeaconWithPsp')
+                    .withArgs(beacon.beaconId, subscriptionId, decodedData, timestamp);
+                  const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                  expect(beaconAfter.value).to.equal(decodedData);
+                  expect(beaconAfter.timestamp).to.equal(timestamp);
+                });
+              });
+              context('Signature is not valid', function () {
+                it('reverts', async function () {
+                  const { roles, dataFeedServerFull, beacons } = await deploy();
+                  const beacon = beacons[0];
+                  const subscriptionId = await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .callStatic.registerBeaconUpdateSubscription(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.relayer.wallet.address,
+                      roles.sponsor.address
+                    );
+                  await dataFeedServerFull
+                    .connect(roles.randomPerson)
+                    .registerBeaconUpdateSubscription(
+                      beacon.airnode.wallet.address,
+                      beacon.templateId,
+                      beacon.beaconUpdateSubscriptionConditions,
+                      beacon.relayer.wallet.address,
+                      roles.sponsor.address
+                    );
+                  const decodedData = 123;
+                  const data = encodeData(decodedData);
+                  const timestamp = await helpers.time.latest();
+                  await expect(
+                    dataFeedServerFull
+                      .connect(beacon.relayer.pspRelayedSponsorWallet)
+                      .fulfillPspBeaconUpdate(
+                        subscriptionId,
+                        beacon.airnode.wallet.address,
+                        beacon.relayer.wallet.address,
+                        roles.sponsor.address,
+                        timestamp,
+                        data,
+                        '0x12345678',
+                        { gasLimit: 500000 }
+                      )
+                  ).to.be.revertedWith('ECDSA: invalid signature length');
+                });
               });
             });
           });
-          context('Does not update timestamp', function () {
+          context('Data is not fresher than Beacon', function () {
             it('reverts', async function () {
               const { roles, dataFeedServerFull, beacons } = await deploy();
               const beacon = beacons[0];
@@ -2585,65 +2422,11 @@ describe('DataFeedServerFull', function () {
 
   describe('updateBeaconSetWithBeacons', function () {
     context('Did not specify less than two Beacons', function () {
-      context('Updates timestamp from a non-zero value', function () {
-        context('Updates value', function () {
-          it('updates Beacon set', async function () {
-            const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
-            // Populate the Beacons
-            const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
-            const currentTimestamp = await helpers.time.latest();
-            const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
-            await Promise.all(
-              beacons.map(async (beacon, index) => {
-                await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
-              })
-            );
-            const beaconSetValue = median(beaconValues);
-            const beaconSetTimestamp = median(beaconTimestamps);
-            const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetBefore.value).to.equal(0);
-            expect(beaconSetBefore.timestamp).to.equal(0);
-            expect(
-              await dataFeedServerFull
-                .connect(roles.randomPerson)
-                .callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.equal(beaconSet.beaconSetId);
-            await expect(dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
-              .to.emit(dataFeedServerFull, 'UpdatedBeaconSetWithBeacons')
-              .withArgs(beaconSet.beaconSetId, beaconSetValue, beaconSetTimestamp);
-            const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-            expect(beaconSetAfter.value).to.equal(beaconSetValue);
-            expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
-          });
-        });
-        context('Does not update value', function () {
-          it('reverts', async function () {
-            const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
-            // Populate the Beacons
-            const beaconValues = [100, 80, 120];
-            const currentTimestamp = await helpers.time.latest();
-            const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
-            await Promise.all(
-              beacons.map(async (beacon, index) => {
-                await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
-              })
-            );
-            // Update the Beacon set
-            await dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
-            // Update the Beacons in a way that it will not affect the aggregated value
-            await updateBeacon(roles, dataFeedServerFull, beacons[1], 79, currentTimestamp + 1);
-            await updateBeacon(roles, dataFeedServerFull, beacons[2], 121, currentTimestamp + 1);
-            await expect(
-              dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
-            ).to.be.revertedWith('Does not update value');
-          });
-        });
-      });
-      context('Updates timestamp from zero', function () {
+      context('Beacons update Beacon set timestamp', function () {
         it('updates Beacon set', async function () {
           const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
           // Populate the Beacons
-          const beaconValues = beacons.map(() => 0);
+          const beaconValues = beacons.map(() => Math.floor(Math.random() * 200 - 100));
           const currentTimestamp = await helpers.time.latest();
           const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
           await Promise.all(
@@ -2669,25 +2452,49 @@ describe('DataFeedServerFull', function () {
           expect(beaconSetAfter.timestamp).to.equal(beaconSetTimestamp);
         });
       });
-      context('Does not update timestamp', function () {
-        it('reverts', async function () {
-          const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
-          // Populate the Beacons
-          const beaconValues = [100, 80, 120];
-          const currentTimestamp = await helpers.time.latest();
-          const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
-          await Promise.all(
-            beacons.map(async (beacon, index) => {
-              await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
-            })
-          );
-          // Update the Beacon set
-          await dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds);
-          // Update the Beacons in a way that it will not affect the aggregated timestamp
-          await updateBeacon(roles, dataFeedServerFull, beacons[0], 101, currentTimestamp + 1);
-          await expect(
-            dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
-          ).to.be.revertedWith('Does not update timestamp');
+      context('Beacons do not update Beacon set timestamp', function () {
+        context('Beacons update Beacon set value', function () {
+          it('updates Beacon set', async function () {
+            const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
+            // Populate the Beacons
+            const beaconValues = [100, 80, 120];
+            const currentTimestamp = await helpers.time.latest();
+            const beaconTimestamps = [currentTimestamp, currentTimestamp, currentTimestamp];
+            await Promise.all(
+              beacons.map(async (beacon, index) => {
+                await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
+              })
+            );
+            const beaconIds = beacons.map((beacon) => {
+              return beacon.beaconId;
+            });
+            await dataFeedServerFull.updateBeaconSetWithBeacons(beaconIds);
+            await updateBeacon(roles, dataFeedServerFull, beacons[0], 110, currentTimestamp + 10);
+            const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetBefore.value).to.equal(100);
+            expect(beaconSetBefore.timestamp).to.equal(currentTimestamp);
+            expect(
+              await dataFeedServerFull
+                .connect(roles.randomPerson)
+                .callStatic.updateBeaconSetWithBeacons(beaconSet.beaconIds)
+            ).to.equal(beaconSet.beaconSetId);
+            await expect(dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds))
+              .to.emit(dataFeedServerFull, 'UpdatedBeaconSetWithBeacons')
+              .withArgs(beaconSet.beaconSetId, 110, currentTimestamp);
+            const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+            expect(beaconSetAfter.value).to.equal(110);
+            expect(beaconSetAfter.timestamp).to.equal(currentTimestamp);
+          });
+        });
+        context('Beacons do not update Beacon set value', function () {
+          it('reverts', async function () {
+            const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
+            // Update Beacon set with recent timestamp
+            await updateBeaconSet(roles, dataFeedServerFull, beacons, 123);
+            await expect(
+              dataFeedServerFull.connect(roles.randomPerson).updateBeaconSetWithBeacons(beaconSet.beaconIds)
+            ).to.be.revertedWith('Does not update Beacon set');
+          });
         });
       });
     });
@@ -2712,7 +2519,7 @@ describe('DataFeedServerFull', function () {
             it('returns true', async function () {
               const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
               // Populate the Beacons
-              const beaconValues = beacons.map(() => 1);
+              const beaconValues = beacons.map(() => 0);
               const currentTimestamp = await helpers.time.latest();
               const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
               await Promise.all(
@@ -2720,8 +2527,8 @@ describe('DataFeedServerFull', function () {
                   await updateBeacon(roles, dataFeedServerFull, beacon, beaconValues[index], beaconTimestamps[index]);
                 })
               );
-              // Even if the Beacon values are very clsoe to zero,
-              // since their timestamps are not zero, the condition will return true
+              // Even if the Beacon values are zero, since their timestamps are not zero,
+              // the condition will return true
               expect(
                 await dataFeedServerFull
                   .connect(roles.randomPerson)
@@ -2992,7 +2799,7 @@ describe('DataFeedServerFull', function () {
         it('updates Beacon set', async function () {
           const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
           // Populate the Beacons
-          const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
+          const beaconValues = beacons.map(() => Math.floor(Math.random() * 200 - 100));
           const currentTimestamp = await helpers.time.latest();
           const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
           await Promise.all(
@@ -3040,7 +2847,7 @@ describe('DataFeedServerFull', function () {
           // We are testing this for the sake of completeness
           const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
           // Populate the Beacons
-          const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
+          const beaconValues = beacons.map(() => Math.floor(Math.random() * 200 - 100));
           const currentTimestamp = await helpers.time.latest();
           const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
           await Promise.all(
@@ -3098,7 +2905,7 @@ describe('DataFeedServerFull', function () {
       it('reverts', async function () {
         const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
         // Populate the Beacons
-        const beaconValues = beacons.map(() => Math.floor(Math.random() * 20000 - 10000));
+        const beaconValues = beacons.map(() => Math.floor(Math.random() * 200 - 100));
         const currentTimestamp = await helpers.time.latest();
         const beaconTimestamps = beacons.map(() => Math.floor(currentTimestamp - Math.random() * 5 * 60));
         await Promise.all(
@@ -3137,87 +2944,11 @@ describe('DataFeedServerFull', function () {
       context('Signature is valid', function () {
         context('Fulfillment data length is correct', function () {
           context('Decoded fulfillment data can be typecasted into int224', function () {
-            context('Updates timestamp from a non-zero value', function () {
-              context('Updates value', function () {
-                it('updates Beacon with signed data', async function () {
-                  const { roles, dataFeedServerFull, beacons } = await deploy();
-                  const beacon = beacons[0];
-                  const beaconValue = Math.floor(Math.random() * 20000 - 10000);
-                  const beaconTimestamp = await helpers.time.latest();
-                  const signature = await testUtils.signData(
-                    beacon.airnode.wallet,
-                    beacon.templateId,
-                    beaconTimestamp,
-                    encodeData(beaconValue)
-                  );
-                  const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                  expect(beaconBefore.value).to.equal(0);
-                  expect(beaconBefore.timestamp).to.equal(0);
-                  await expect(
-                    dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .updateBeaconWithSignedData(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beaconTimestamp,
-                        encodeData(beaconValue),
-                        signature
-                      )
-                  )
-                    .to.emit(dataFeedServerFull, 'UpdatedBeaconWithSignedData')
-                    .withArgs(beacon.beaconId, beaconValue, beaconTimestamp);
-                  const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                  expect(beaconAfter.value).to.equal(beaconValue);
-                  expect(beaconAfter.timestamp).to.equal(beaconTimestamp);
-                });
-              });
-              context('Does not update value', function () {
-                it('reverts', async function () {
-                  const { roles, dataFeedServerFull, beacons } = await deploy();
-                  const beacon = beacons[0];
-                  const beaconValue = Math.floor(Math.random() * 20000 - 10000);
-                  const beaconTimestampFirst = await helpers.time.latest();
-                  const signatureFirst = await testUtils.signData(
-                    beacon.airnode.wallet,
-                    beacon.templateId,
-                    beaconTimestampFirst,
-                    encodeData(beaconValue)
-                  );
-                  await dataFeedServerFull
-                    .connect(roles.randomPerson)
-                    .updateBeaconWithSignedData(
-                      beacon.airnode.wallet.address,
-                      beacon.templateId,
-                      beaconTimestampFirst,
-                      encodeData(beaconValue),
-                      signatureFirst
-                    );
-                  const beaconTimestampSecond = await helpers.time.latest();
-                  const signatureSecond = await testUtils.signData(
-                    beacon.airnode.wallet,
-                    beacon.templateId,
-                    beaconTimestampSecond,
-                    encodeData(beaconValue)
-                  );
-                  await expect(
-                    dataFeedServerFull
-                      .connect(roles.randomPerson)
-                      .updateBeaconWithSignedData(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        beaconTimestampSecond,
-                        encodeData(beaconValue),
-                        signatureSecond
-                      )
-                  ).to.be.revertedWith('Does not update value');
-                });
-              });
-            });
-            context('Updates timestamp from zero', function () {
+            context('Updates timestamp', function () {
               it('updates Beacon with signed data', async function () {
                 const { roles, dataFeedServerFull, beacons } = await deploy();
                 const beacon = beacons[0];
-                const beaconValue = 0;
+                const beaconValue = Math.floor(Math.random() * 200 - 100);
                 const beaconTimestamp = await helpers.time.latest();
                 const signature = await testUtils.signData(
                   beacon.airnode.wallet,
@@ -3250,7 +2981,7 @@ describe('DataFeedServerFull', function () {
               it('reverts', async function () {
                 const { roles, dataFeedServerFull, beacons } = await deploy();
                 const beacon = beacons[0];
-                const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+                const beaconValue = Math.floor(Math.random() * 200 - 100);
                 const beaconTimestamp = await helpers.time.latest();
                 const signature = await testUtils.signData(
                   beacon.airnode.wallet,
@@ -3329,7 +3060,7 @@ describe('DataFeedServerFull', function () {
           it('reverts', async function () {
             const { roles, dataFeedServerFull, beacons } = await deploy();
             const beacon = beacons[0];
-            const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconValue = Math.floor(Math.random() * 200 - 100);
             const beaconTimestamp = await helpers.time.latest();
             const signature = await testUtils.signData(
               beacon.airnode.wallet,
@@ -3355,7 +3086,7 @@ describe('DataFeedServerFull', function () {
         it('reverts', async function () {
           const { roles, dataFeedServerFull, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           await expect(
             dataFeedServerFull
@@ -3375,7 +3106,7 @@ describe('DataFeedServerFull', function () {
       it('reverts', async function () {
         const { roles, dataFeedServerFull, beacons } = await deploy();
         const beacon = beacons[0];
-        const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+        const beaconValue = Math.floor(Math.random() * 200 - 100);
         const nextTimestamp = (await helpers.time.latest()) + 1;
         await helpers.time.setNextBlockTimestamp(nextTimestamp);
         const beaconTimestamp = nextTimestamp + 60 * 60 + 1;
@@ -3402,7 +3133,7 @@ describe('DataFeedServerFull', function () {
       it('reverts', async function () {
         const { roles, dataFeedServerFull, beacons } = await deploy();
         const beacon = beacons[0];
-        const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+        const beaconValue = Math.floor(Math.random() * 200 - 100);
         const nextTimestamp = (await helpers.time.latest()) + 1;
         await helpers.time.setNextBlockTimestamp(nextTimestamp);
         const beaconTimestamp = 0;
@@ -3429,242 +3160,15 @@ describe('DataFeedServerFull', function () {
 
   describe('updateOevProxyDataFeedWithSignedData', function () {
     context('Timestamp is valid', function () {
-      context('Fulfillment data length is correct', function () {
-        context('Decoded fulfillment data can be typecasted into int224', function () {
-          context('Updates timestamp from a non-zero value', function () {
-            context('Updates value', function () {
-              context('Updated value not same as base feed value', function () {
-                context('More than one Beacon is specified', function () {
-                  context('There are no invalid signatures', function () {
-                    context('There are enough signatures to constitute an absolute majority', function () {
-                      context('Data in packed signatures is consistent with the data feed ID', function () {
-                        it('updates OEV proxy Beacon set with signed data', async function () {
-                          const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                          await updateProxyDataFeed(
-                            roles,
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            beacons,
-                            testUtils.generateRandomBytes32(),
-                            beaconSet.beaconSetId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          // Randomly omit one of the signatures
-                          const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                          const signatures = await Promise.all(
-                            beacons.map(async (beacon, index) => {
-                              if (index === omitSignatureAtIndex) {
-                                return '0x';
-                              } else {
-                                return await testUtils.signOevData(
-                                  dataFeedServerFull,
-                                  oevProxy.address,
-                                  beaconSet.beaconSetId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  roles.searcher.address,
-                                  bidAmount,
-                                  beacon.airnode.wallet,
-                                  beacon.templateId
-                                );
-                              }
-                            })
-                          );
-                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                            return packOevUpdateSignature(
-                              beacons[index].airnode.wallet.address,
-                              beacons[index].templateId,
-                              signature
-                            );
-                          });
-                          const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                          expect(beaconSetBefore.value).to.equal(0);
-                          expect(beaconSetBefore.timestamp).to.equal(0);
-                          const oevProxyBeaconSetBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beaconSet.beaconSetId
-                          );
-                          expect(oevProxyBeaconSetBefore.value).to.equal(1);
-                          expect(oevProxyBeaconSetBefore.timestamp).to.equal(1);
-                          await expect(
-                            dataFeedServerFull
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                packedOevUpdateSignatures,
-                                { value: bidAmount }
-                              )
-                          )
-                            .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconSetWithSignedData')
-                            .withArgs(
-                              beaconSet.beaconSetId,
-                              oevProxy.address,
-                              updateId,
-                              oevUpdateValue,
-                              oevUpdateTimestamp
-                            );
-                          const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                          expect(beaconSetAfter.value).to.equal(0);
-                          expect(beaconSetAfter.timestamp).to.equal(0);
-                          const oevProxyBeaconSetAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beaconSet.beaconSetId
-                          );
-                          expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
-                          expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
-                        });
-                      });
-                      context('Data in packed signatures is not consistent with the data feed ID', function () {
-                        it('reverts', async function () {
-                          const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                          await updateProxyDataFeed(
-                            roles,
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            beacons,
-                            testUtils.generateRandomBytes32(),
-                            beaconSet.beaconSetId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          // Randomly omit one of the signatures
-                          const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                          const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                          const signatures = await Promise.all(
-                            beacons.map(async (beacon, index) => {
-                              if (index === omitSignatureAtIndex) {
-                                return '0x';
-                              } else {
-                                return await testUtils.signOevData(
-                                  dataFeedServerFull,
-                                  oevProxy.address,
-                                  spoofedDataFeedId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  roles.searcher.address,
-                                  bidAmount,
-                                  beacon.airnode.wallet,
-                                  beacon.templateId
-                                );
-                              }
-                            })
-                          );
-                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                            return packOevUpdateSignature(
-                              beacons[index].airnode.wallet.address,
-                              beacons[index].templateId,
-                              signature
-                            );
-                          });
-                          await expect(
-                            dataFeedServerFull
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                spoofedDataFeedId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                packedOevUpdateSignatures,
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Beacon set ID mismatch');
-                        });
-                      });
-                    });
-                    context('There are not enough signatures to constitute an absolute majority', function () {
-                      it('reverts', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                        await updateProxyDataFeed(
-                          roles,
-                          dataFeedServerFull,
-                          oevProxy.address,
-                          beacons,
-                          testUtils.generateRandomBytes32(),
-                          beaconSet.beaconSetId,
-                          1,
-                          1
-                        );
-                        const oevUpdateValue = 105;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit two of the signatures
-                        const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index !== includeSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return await testUtils.signOevData(
-                                dataFeedServerFull,
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                roles.searcher.address,
-                                bidAmount,
-                                beacon.airnode.wallet,
-                                beacon.templateId
-                              );
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beaconSet.beaconSetId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Not enough signatures');
-                      });
-                    });
-                  });
-                  context('There are invalid signatures', function () {
-                    it('reverts', async function () {
+      context('Updates timestamp', function () {
+        context('Fulfillment data length is correct', function () {
+          context('Decoded fulfillment data can be typecasted into int224', function () {
+            context('More than one Beacon is specified', function () {
+              context('There are no invalid signatures', function () {
+                context('There are enough signatures to constitute an absolute majority', function () {
+                  context('Data in packed signatures is consistent with the data feed ID', function () {
+                    it('updates OEV proxy Beacon set with signed data', async function () {
                       const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                      await updateProxyDataFeed(
-                        roles,
-                        dataFeedServerFull,
-                        oevProxy.address,
-                        beacons,
-                        testUtils.generateRandomBytes32(),
-                        beaconSet.beaconSetId,
-                        1,
-                        1
-                      );
                       const oevUpdateValue = 105;
                       const currentTimestamp = await helpers.time.latest();
                       const oevUpdateTimestamp = currentTimestamp + 1;
@@ -3675,1064 +3179,6 @@ describe('DataFeedServerFull', function () {
                       const signatures = await Promise.all(
                         beacons.map(async (beacon, index) => {
                           if (index === omitSignatureAtIndex) {
-                            return '0x';
-                          } else {
-                            return '0x123456';
-                          }
-                        })
-                      );
-                      const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                        return packOevUpdateSignature(
-                          beacons[index].airnode.wallet.address,
-                          beacons[index].templateId,
-                          signature
-                        );
-                      });
-                      await expect(
-                        dataFeedServerFull
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beaconSet.beaconSetId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            packedOevUpdateSignatures,
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('ECDSA: invalid signature length');
-                    });
-                  });
-                });
-                context('One Beacon is specified', function () {
-                  context('The signature is not invalid', function () {
-                    context('The signature is not omitted', function () {
-                      context('Data in the packed signature is consistent with the data feed ID', function () {
-                        it('updates OEV proxy Beacon with signed data', async function () {
-                          const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                          const beacon = beacons[0];
-                          await updateProxyDataFeed(
-                            roles,
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            [beacon],
-                            testUtils.generateRandomBytes32(),
-                            beacon.beaconId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          const signature = await testUtils.signOevData(
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            roles.searcher.address,
-                            bidAmount,
-                            beacon.airnode.wallet,
-                            beacon.templateId
-                          );
-                          const packedOevUpdateSignature = packOevUpdateSignature(
-                            beacon.airnode.wallet.address,
-                            beacon.templateId,
-                            signature
-                          );
-                          const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                          expect(beaconBefore.value).to.equal(0);
-                          expect(beaconBefore.timestamp).to.equal(0);
-                          const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beacon.beaconId
-                          );
-                          expect(oevProxyBeaconBefore.value).to.equal(1);
-                          expect(oevProxyBeaconBefore.timestamp).to.equal(1);
-                          await expect(
-                            dataFeedServerFull
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beacon.beaconId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                [packedOevUpdateSignature],
-                                { value: bidAmount }
-                              )
-                          )
-                            .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconWithSignedData')
-                            .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
-                          const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                          expect(beaconAfter.value).to.equal(0);
-                          expect(beaconAfter.timestamp).to.equal(0);
-                          const oevProxyBeaconAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                            oevProxy.address,
-                            beacon.beaconId
-                          );
-                          expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
-                          expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
-                        });
-                      });
-                      context('Data in the packed signature is not consistent with the data feed ID', function () {
-                        it('reverts', async function () {
-                          const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                          const beacon = beacons[0];
-                          await updateProxyDataFeed(
-                            roles,
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            [beacon],
-                            testUtils.generateRandomBytes32(),
-                            beacon.beaconId,
-                            1,
-                            1
-                          );
-                          const oevUpdateValue = 105;
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                          const signature = await testUtils.signOevData(
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            spoofedDataFeedId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            roles.searcher.address,
-                            bidAmount,
-                            beacon.airnode.wallet,
-                            beacon.templateId
-                          );
-                          const packedOevUpdateSignature = packOevUpdateSignature(
-                            beacon.airnode.wallet.address,
-                            beacon.templateId,
-                            signature
-                          );
-                          await expect(
-                            dataFeedServerFull
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                spoofedDataFeedId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                [packedOevUpdateSignature],
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Beacon ID mismatch');
-                        });
-                      });
-                    });
-                    context('The signature is omitted', function () {
-                      it('reverts', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        await updateProxyDataFeed(
-                          roles,
-                          dataFeedServerFull,
-                          oevProxy.address,
-                          [beacon],
-                          testUtils.generateRandomBytes32(),
-                          beacon.beaconId,
-                          1,
-                          1
-                        );
-                        const oevUpdateValue = 105;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          '0x'
-                        );
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Missing signature');
-                      });
-                    });
-                  });
-                  context('The signature is invalid', function () {
-                    it('reverts', async function () {
-                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                      const beacon = beacons[0];
-                      await updateProxyDataFeed(
-                        roles,
-                        dataFeedServerFull,
-                        oevProxy.address,
-                        [beacon],
-                        testUtils.generateRandomBytes32(),
-                        beacon.beaconId,
-                        1,
-                        1
-                      );
-                      const oevUpdateValue = 105;
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      const packedOevUpdateSignature = packOevUpdateSignature(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        '0x123456'
-                      );
-                      await expect(
-                        dataFeedServerFull
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            [packedOevUpdateSignature],
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('ECDSA: invalid signature length');
-                    });
-                  });
-                });
-                context('No Beacon is specified', function () {
-                  it('reverts', async function () {
-                    const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                    const beacon = beacons[0];
-                    await updateProxyDataFeed(
-                      roles,
-                      dataFeedServerFull,
-                      oevProxy.address,
-                      [beacon],
-                      testUtils.generateRandomBytes32(),
-                      beacon.beaconId,
-                      1,
-                      1
-                    );
-                    const oevUpdateValue = 105;
-                    const currentTimestamp = await helpers.time.latest();
-                    const oevUpdateTimestamp = currentTimestamp + 1;
-                    const bidAmount = 10000;
-                    const updateId = testUtils.generateRandomBytes32();
-                    await expect(
-                      dataFeedServerFull
-                        .connect(roles.searcher)
-                        .updateOevProxyDataFeedWithSignedData(
-                          oevProxy.address,
-                          beacon.beaconId,
-                          updateId,
-                          oevUpdateTimestamp,
-                          encodeData(oevUpdateValue),
-                          [],
-                          { value: bidAmount }
-                        )
-                    ).to.be.revertedWith('Did not specify any Beacons');
-                  });
-                });
-              });
-              context('Updated value same as base feed value', function () {
-                context('Current OEV proxy data feed timestamp is larger than base data feed timestamp', function () {
-                  context('More than one Beacon is specified', function () {
-                    context('There are no invalid signatures', function () {
-                      context('There are enough signatures to constitute an absolute majority', function () {
-                        context('Data in packed signatures is consistent with the data feed ID', function () {
-                          it('updates OEV proxy Beacon set with signed data', async function () {
-                            const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                            await updateProxyDataFeed(
-                              roles,
-                              dataFeedServerFull,
-                              oevProxy.address,
-                              beacons,
-                              testUtils.generateRandomBytes32(),
-                              beaconSet.beaconSetId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeaconSet(roles, dataFeedServerFull, beacons, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            // Randomly omit one of the signatures
-                            const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                            const signatures = await Promise.all(
-                              beacons.map(async (beacon, index) => {
-                                if (index === omitSignatureAtIndex) {
-                                  return '0x';
-                                } else {
-                                  return await testUtils.signOevData(
-                                    dataFeedServerFull,
-                                    oevProxy.address,
-                                    beaconSet.beaconSetId,
-                                    updateId,
-                                    oevUpdateTimestamp,
-                                    encodeData(oevUpdateValue),
-                                    roles.searcher.address,
-                                    bidAmount,
-                                    beacon.airnode.wallet,
-                                    beacon.templateId
-                                  );
-                                }
-                              })
-                            );
-                            const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                              return packOevUpdateSignature(
-                                beacons[index].airnode.wallet.address,
-                                beacons[index].templateId,
-                                signature
-                              );
-                            });
-                            const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                            expect(beaconSetBefore.value).to.equal(105);
-                            expect(beaconSetBefore.timestamp).to.equal(1);
-                            const oevProxyBeaconSetBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beaconSet.beaconSetId
-                            );
-                            expect(oevProxyBeaconSetBefore.value).to.equal(1);
-                            expect(oevProxyBeaconSetBefore.timestamp).to.equal(2);
-                            await expect(
-                              dataFeedServerFull
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  beaconSet.beaconSetId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  packedOevUpdateSignatures,
-                                  { value: bidAmount }
-                                )
-                            )
-                              .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconSetWithSignedData')
-                              .withArgs(
-                                beaconSet.beaconSetId,
-                                oevProxy.address,
-                                updateId,
-                                oevUpdateValue,
-                                oevUpdateTimestamp
-                              );
-                            const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                            expect(beaconSetAfter.value).to.equal(105);
-                            expect(beaconSetAfter.timestamp).to.equal(1);
-                            const oevProxyBeaconSetAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beaconSet.beaconSetId
-                            );
-                            expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
-                            expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
-                          });
-                        });
-                        context('Data in packed signatures is not consistent with the data feed ID', function () {
-                          it('reverts', async function () {
-                            const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                            await updateProxyDataFeed(
-                              roles,
-                              dataFeedServerFull,
-                              oevProxy.address,
-                              beacons,
-                              testUtils.generateRandomBytes32(),
-                              beaconSet.beaconSetId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeaconSet(roles, dataFeedServerFull, beacons, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            // Randomly omit one of the signatures
-                            const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                            const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                            const signatures = await Promise.all(
-                              beacons.map(async (beacon, index) => {
-                                if (index === omitSignatureAtIndex) {
-                                  return '0x';
-                                } else {
-                                  return await testUtils.signOevData(
-                                    dataFeedServerFull,
-                                    oevProxy.address,
-                                    spoofedDataFeedId,
-                                    updateId,
-                                    oevUpdateTimestamp,
-                                    encodeData(oevUpdateValue),
-                                    roles.searcher.address,
-                                    bidAmount,
-                                    beacon.airnode.wallet,
-                                    beacon.templateId
-                                  );
-                                }
-                              })
-                            );
-                            const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                              return packOevUpdateSignature(
-                                beacons[index].airnode.wallet.address,
-                                beacons[index].templateId,
-                                signature
-                              );
-                            });
-                            await expect(
-                              dataFeedServerFull
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  spoofedDataFeedId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  packedOevUpdateSignatures,
-                                  { value: bidAmount }
-                                )
-                            ).to.be.revertedWith('Beacon set ID mismatch');
-                          });
-                        });
-                      });
-                      context('There are not enough signatures to constitute an absolute majority', function () {
-                        it('reverts', async function () {
-                          const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                          await updateProxyDataFeed(
-                            roles,
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            beacons,
-                            testUtils.generateRandomBytes32(),
-                            beaconSet.beaconSetId,
-                            1,
-                            2
-                          );
-                          const oevUpdateValue = 105;
-                          await updateBeaconSet(roles, dataFeedServerFull, beacons, oevUpdateValue, 1);
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          // Randomly omit two of the signatures
-                          const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                          const signatures = await Promise.all(
-                            beacons.map(async (beacon, index) => {
-                              if (index !== includeSignatureAtIndex) {
-                                return '0x';
-                              } else {
-                                return await testUtils.signOevData(
-                                  dataFeedServerFull,
-                                  oevProxy.address,
-                                  beaconSet.beaconSetId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  roles.searcher.address,
-                                  bidAmount,
-                                  beacon.airnode.wallet,
-                                  beacon.templateId
-                                );
-                              }
-                            })
-                          );
-                          const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                            return packOevUpdateSignature(
-                              beacons[index].airnode.wallet.address,
-                              beacons[index].templateId,
-                              signature
-                            );
-                          });
-                          await expect(
-                            dataFeedServerFull
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                packedOevUpdateSignatures,
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Not enough signatures');
-                        });
-                      });
-                    });
-                    context('There are invalid signatures', function () {
-                      it('reverts', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                        await updateProxyDataFeed(
-                          roles,
-                          dataFeedServerFull,
-                          oevProxy.address,
-                          beacons,
-                          testUtils.generateRandomBytes32(),
-                          beaconSet.beaconSetId,
-                          1,
-                          2
-                        );
-                        const oevUpdateValue = 105;
-                        await updateBeaconSet(roles, dataFeedServerFull, beacons, oevUpdateValue, 1);
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit one of the signatures
-                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index === omitSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return '0x123456';
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beaconSet.beaconSetId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('ECDSA: invalid signature length');
-                      });
-                    });
-                  });
-                  context('One Beacon is specified', function () {
-                    context('The signature is not invalid', function () {
-                      context('The signature is not omitted', function () {
-                        context('Data in the packed signature is consistent with the data feed ID', function () {
-                          it('updates OEV proxy Beacon with signed data', async function () {
-                            const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                            const beacon = beacons[0];
-                            await updateProxyDataFeed(
-                              roles,
-                              dataFeedServerFull,
-                              oevProxy.address,
-                              [beacon],
-                              testUtils.generateRandomBytes32(),
-                              beacon.beaconId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeacon(roles, dataFeedServerFull, beacon, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            const signature = await testUtils.signOevData(
-                              dataFeedServerFull,
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              roles.searcher.address,
-                              bidAmount,
-                              beacon.airnode.wallet,
-                              beacon.templateId
-                            );
-                            const packedOevUpdateSignature = packOevUpdateSignature(
-                              beacon.airnode.wallet.address,
-                              beacon.templateId,
-                              signature
-                            );
-                            const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                            expect(beaconBefore.value).to.equal(105);
-                            expect(beaconBefore.timestamp).to.equal(1);
-                            const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beacon.beaconId
-                            );
-                            expect(oevProxyBeaconBefore.value).to.equal(1);
-                            expect(oevProxyBeaconBefore.timestamp).to.equal(2);
-                            await expect(
-                              dataFeedServerFull
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  beacon.beaconId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  [packedOevUpdateSignature],
-                                  { value: bidAmount }
-                                )
-                            )
-                              .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconWithSignedData')
-                              .withArgs(
-                                beacon.beaconId,
-                                oevProxy.address,
-                                updateId,
-                                oevUpdateValue,
-                                oevUpdateTimestamp
-                              );
-                            const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                            expect(beaconAfter.value).to.equal(105);
-                            expect(beaconAfter.timestamp).to.equal(1);
-                            const oevProxyBeaconAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                              oevProxy.address,
-                              beacon.beaconId
-                            );
-                            expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
-                            expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
-                          });
-                        });
-                        context('Data in the packed signature is not consistent with the data feed ID', function () {
-                          it('reverts', async function () {
-                            const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                            const beacon = beacons[0];
-                            await updateProxyDataFeed(
-                              roles,
-                              dataFeedServerFull,
-                              oevProxy.address,
-                              [beacon],
-                              testUtils.generateRandomBytes32(),
-                              beacon.beaconId,
-                              1,
-                              2
-                            );
-                            const oevUpdateValue = 105;
-                            await updateBeacon(roles, dataFeedServerFull, beacon, oevUpdateValue, 1);
-                            const currentTimestamp = await helpers.time.latest();
-                            const oevUpdateTimestamp = currentTimestamp + 1;
-                            const bidAmount = 10000;
-                            const updateId = testUtils.generateRandomBytes32();
-                            const spoofedDataFeedId = testUtils.generateRandomBytes32();
-                            const signature = await testUtils.signOevData(
-                              dataFeedServerFull,
-                              oevProxy.address,
-                              spoofedDataFeedId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              roles.searcher.address,
-                              bidAmount,
-                              beacon.airnode.wallet,
-                              beacon.templateId
-                            );
-                            const packedOevUpdateSignature = packOevUpdateSignature(
-                              beacon.airnode.wallet.address,
-                              beacon.templateId,
-                              signature
-                            );
-                            await expect(
-                              dataFeedServerFull
-                                .connect(roles.searcher)
-                                .updateOevProxyDataFeedWithSignedData(
-                                  oevProxy.address,
-                                  spoofedDataFeedId,
-                                  updateId,
-                                  oevUpdateTimestamp,
-                                  encodeData(oevUpdateValue),
-                                  [packedOevUpdateSignature],
-                                  { value: bidAmount }
-                                )
-                            ).to.be.revertedWith('Beacon ID mismatch');
-                          });
-                        });
-                      });
-                      context('The signature is omitted', function () {
-                        it('reverts', async function () {
-                          const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                          const beacon = beacons[0];
-                          await updateProxyDataFeed(
-                            roles,
-                            dataFeedServerFull,
-                            oevProxy.address,
-                            [beacon],
-                            testUtils.generateRandomBytes32(),
-                            beacon.beaconId,
-                            1,
-                            2
-                          );
-                          const oevUpdateValue = 105;
-                          await updateBeacon(roles, dataFeedServerFull, beacon, oevUpdateValue, 1);
-                          const currentTimestamp = await helpers.time.latest();
-                          const oevUpdateTimestamp = currentTimestamp + 1;
-                          const bidAmount = 10000;
-                          const updateId = testUtils.generateRandomBytes32();
-                          const packedOevUpdateSignature = packOevUpdateSignature(
-                            beacon.airnode.wallet.address,
-                            beacon.templateId,
-                            '0x'
-                          );
-                          await expect(
-                            dataFeedServerFull
-                              .connect(roles.searcher)
-                              .updateOevProxyDataFeedWithSignedData(
-                                oevProxy.address,
-                                beacon.beaconId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                [packedOevUpdateSignature],
-                                { value: bidAmount }
-                              )
-                          ).to.be.revertedWith('Missing signature');
-                        });
-                      });
-                    });
-                    context('The signature is invalid', function () {
-                      it('reverts', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        await updateProxyDataFeed(
-                          roles,
-                          dataFeedServerFull,
-                          oevProxy.address,
-                          [beacon],
-                          testUtils.generateRandomBytes32(),
-                          beacon.beaconId,
-                          1,
-                          2
-                        );
-                        const oevUpdateValue = 105;
-                        await updateBeacon(roles, dataFeedServerFull, beacon, oevUpdateValue, 1);
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          '0x123456'
-                        );
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('ECDSA: invalid signature length');
-                      });
-                    });
-                  });
-                  context('No Beacon is specified', function () {
-                    it('reverts', async function () {
-                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                      const beacon = beacons[0];
-                      await updateProxyDataFeed(
-                        roles,
-                        dataFeedServerFull,
-                        oevProxy.address,
-                        [beacon],
-                        testUtils.generateRandomBytes32(),
-                        beacon.beaconId,
-                        1,
-                        2
-                      );
-                      const oevUpdateValue = 105;
-                      await updateBeacon(roles, dataFeedServerFull, beacon, oevUpdateValue, 1);
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      await expect(
-                        dataFeedServerFull
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            [],
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('Did not specify any Beacons');
-                    });
-                  });
-                });
-                context(
-                  'Current OEV proxy data feed timestamp is not larger than base data feed timestamp',
-                  function () {
-                    it('reverts', async function () {
-                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                      const beacon = beacons[0];
-                      const oevUpdateValue = 105;
-                      await updateBeacon(roles, dataFeedServerFull, beacon, oevUpdateValue, 1);
-                      const updateId = testUtils.generateRandomBytes32();
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const signature = await testUtils.signOevData(
-                        dataFeedServerFull,
-                        oevProxy.address,
-                        beacon.beaconId,
-                        updateId,
-                        oevUpdateTimestamp,
-                        encodeData(oevUpdateValue),
-                        roles.searcher.address,
-                        bidAmount,
-                        beacon.airnode.wallet,
-                        beacon.templateId
-                      );
-                      const packedOevUpdateSignature = packOevUpdateSignature(
-                        beacon.airnode.wallet.address,
-                        beacon.templateId,
-                        signature
-                      );
-                      await expect(
-                        dataFeedServerFull
-                          .connect(roles.searcher)
-                          .updateOevProxyDataFeedWithSignedData(
-                            oevProxy.address,
-                            beacon.beaconId,
-                            updateId,
-                            oevUpdateTimestamp,
-                            encodeData(oevUpdateValue),
-                            [packedOevUpdateSignature],
-                            { value: bidAmount }
-                          )
-                      ).to.be.revertedWith('Repeats base feed update');
-                    });
-                  }
-                );
-              });
-            });
-            context('Does not update value', function () {
-              it('reverts', async function () {
-                const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                const beacon = beacons[0];
-                const oevUpdateValue = 105;
-                await updateProxyDataFeed(
-                  roles,
-                  dataFeedServerFull,
-                  oevProxy.address,
-                  [beacon],
-                  testUtils.generateRandomBytes32(),
-                  beacon.beaconId,
-                  oevUpdateValue,
-                  1
-                );
-                const updateId = testUtils.generateRandomBytes32();
-                const currentTimestamp = await helpers.time.latest();
-                const oevUpdateTimestamp = currentTimestamp + 1;
-                const bidAmount = 10000;
-                const signature = await testUtils.signOevData(
-                  dataFeedServerFull,
-                  oevProxy.address,
-                  beacon.beaconId,
-                  updateId,
-                  oevUpdateTimestamp,
-                  encodeData(oevUpdateValue),
-                  roles.searcher.address,
-                  bidAmount,
-                  beacon.airnode.wallet,
-                  beacon.templateId
-                );
-                const packedOevUpdateSignature = packOevUpdateSignature(
-                  beacon.airnode.wallet.address,
-                  beacon.templateId,
-                  signature
-                );
-                await expect(
-                  dataFeedServerFull
-                    .connect(roles.searcher)
-                    .updateOevProxyDataFeedWithSignedData(
-                      oevProxy.address,
-                      beacon.beaconId,
-                      updateId,
-                      oevUpdateTimestamp,
-                      encodeData(oevUpdateValue),
-                      [packedOevUpdateSignature],
-                      { value: bidAmount }
-                    )
-                ).to.be.revertedWith('Does not update value');
-              });
-            });
-          });
-          context('Updates timestamp from zero', function () {
-            context('Updated value not same as base feed value', function () {
-              context('More than one Beacon is specified', function () {
-                context('There are no invalid signatures', function () {
-                  context('There are enough signatures to constitute an absolute majority', function () {
-                    context('Data in packed signatures is consistent with the data feed ID', function () {
-                      it('updates OEV proxy Beacon set with signed data', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                        await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit one of the signatures
-                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index === omitSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return await testUtils.signOevData(
-                                dataFeedServerFull,
-                                oevProxy.address,
-                                beaconSet.beaconSetId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                roles.searcher.address,
-                                bidAmount,
-                                beacon.airnode.wallet,
-                                beacon.templateId
-                              );
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                        expect(beaconSetBefore.value).to.equal(1);
-                        expect(beaconSetBefore.timestamp).to.equal(1);
-                        const oevProxyBeaconSetBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beaconSet.beaconSetId
-                        );
-                        expect(oevProxyBeaconSetBefore.value).to.equal(0);
-                        expect(oevProxyBeaconSetBefore.timestamp).to.equal(0);
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beaconSet.beaconSetId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        )
-                          .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconSetWithSignedData')
-                          .withArgs(
-                            beaconSet.beaconSetId,
-                            oevProxy.address,
-                            updateId,
-                            oevUpdateValue,
-                            oevUpdateTimestamp
-                          );
-                        const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
-                        expect(beaconSetAfter.value).to.equal(1);
-                        expect(beaconSetAfter.timestamp).to.equal(1);
-                        const oevProxyBeaconSetAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beaconSet.beaconSetId
-                        );
-                        expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
-                        expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
-                      });
-                    });
-                    context('Data in packed signatures is not consistent with the data feed ID', function () {
-                      it('reverts', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                        const spoofedDataFeedId = ethers.utils.keccak256(
-                          ethers.utils.defaultAbiCoder.encode(
-                            ['bytes32[]'],
-                            [[beacons[0].beaconId, beacons[1].beaconId]]
-                          )
-                        );
-                        await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
-                        await dataFeedServerFull.updateBeaconSetWithBeacons([beacons[0].beaconId, beacons[1].beaconId]);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        // Randomly omit one of the signatures
-                        const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                        const signatures = await Promise.all(
-                          beacons.map(async (beacon, index) => {
-                            if (index === omitSignatureAtIndex) {
-                              return '0x';
-                            } else {
-                              return await testUtils.signOevData(
-                                dataFeedServerFull,
-                                oevProxy.address,
-                                spoofedDataFeedId,
-                                updateId,
-                                oevUpdateTimestamp,
-                                encodeData(oevUpdateValue),
-                                roles.searcher.address,
-                                bidAmount,
-                                beacon.airnode.wallet,
-                                beacon.templateId
-                              );
-                            }
-                          })
-                        );
-                        const packedOevUpdateSignatures = signatures.map((signature, index) => {
-                          return packOevUpdateSignature(
-                            beacons[index].airnode.wallet.address,
-                            beacons[index].templateId,
-                            signature
-                          );
-                        });
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              spoofedDataFeedId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              packedOevUpdateSignatures,
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Beacon set ID mismatch');
-                      });
-                    });
-                  });
-                  context('There are not enough signatures to constitute an absolute majority', function () {
-                    it('reverts', async function () {
-                      const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                      await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
-                      const oevUpdateValue = 0;
-                      const currentTimestamp = await helpers.time.latest();
-                      const oevUpdateTimestamp = currentTimestamp + 1;
-                      const bidAmount = 10000;
-                      const updateId = testUtils.generateRandomBytes32();
-                      // Randomly omit two of the signatures
-                      const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
-                      const signatures = await Promise.all(
-                        beacons.map(async (beacon, index) => {
-                          if (index !== includeSignatureAtIndex) {
                             return '0x';
                           } else {
                             return await testUtils.signOevData(
@@ -4757,6 +3203,15 @@ describe('DataFeedServerFull', function () {
                           signature
                         );
                       });
+                      const beaconSetBefore = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+                      expect(beaconSetBefore.value).to.equal(0);
+                      expect(beaconSetBefore.timestamp).to.equal(0);
+                      const oevProxyBeaconSetBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beaconSet.beaconSetId
+                      );
+                      expect(oevProxyBeaconSetBefore.value).to.equal(0);
+                      expect(oevProxyBeaconSetBefore.timestamp).to.equal(0);
                       await expect(
                         dataFeedServerFull
                           .connect(roles.searcher)
@@ -4769,27 +3224,107 @@ describe('DataFeedServerFull', function () {
                             packedOevUpdateSignatures,
                             { value: bidAmount }
                           )
-                      ).to.be.revertedWith('Not enough signatures');
+                      )
+                        .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconSetWithSignedData')
+                        .withArgs(
+                          beaconSet.beaconSetId,
+                          oevProxy.address,
+                          updateId,
+                          oevUpdateValue,
+                          oevUpdateTimestamp
+                        );
+                      const beaconSetAfter = await dataFeedServerFull.dataFeeds(beaconSet.beaconSetId);
+                      expect(beaconSetAfter.value).to.equal(0);
+                      expect(beaconSetAfter.timestamp).to.equal(0);
+                      const oevProxyBeaconSetAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beaconSet.beaconSetId
+                      );
+                      expect(oevProxyBeaconSetAfter.value).to.equal(oevUpdateValue);
+                      expect(oevProxyBeaconSetAfter.timestamp).to.equal(oevUpdateTimestamp);
+                    });
+                  });
+                  context('Data in packed signatures is not consistent with the data feed ID', function () {
+                    it('reverts', async function () {
+                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                      const oevUpdateValue = 105;
+                      const currentTimestamp = await helpers.time.latest();
+                      const oevUpdateTimestamp = currentTimestamp + 1;
+                      const bidAmount = 10000;
+                      const updateId = testUtils.generateRandomBytes32();
+                      // Randomly omit one of the signatures
+                      const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                      const spoofedDataFeedId = testUtils.generateRandomBytes32();
+                      const signatures = await Promise.all(
+                        beacons.map(async (beacon, index) => {
+                          if (index === omitSignatureAtIndex) {
+                            return '0x';
+                          } else {
+                            return await testUtils.signOevData(
+                              dataFeedServerFull,
+                              oevProxy.address,
+                              spoofedDataFeedId,
+                              updateId,
+                              oevUpdateTimestamp,
+                              encodeData(oevUpdateValue),
+                              roles.searcher.address,
+                              bidAmount,
+                              beacon.airnode.wallet,
+                              beacon.templateId
+                            );
+                          }
+                        })
+                      );
+                      const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                        return packOevUpdateSignature(
+                          beacons[index].airnode.wallet.address,
+                          beacons[index].templateId,
+                          signature
+                        );
+                      });
+                      await expect(
+                        dataFeedServerFull
+                          .connect(roles.searcher)
+                          .updateOevProxyDataFeedWithSignedData(
+                            oevProxy.address,
+                            spoofedDataFeedId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            packedOevUpdateSignatures,
+                            { value: bidAmount }
+                          )
+                      ).to.be.revertedWith('Beacon set ID mismatch');
                     });
                   });
                 });
-                context('There are invalid signatures', function () {
+                context('There are not enough signatures to constitute an absolute majority', function () {
                   it('reverts', async function () {
                     const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
-                    await updateBeaconSet(roles, dataFeedServerFull, beacons, 1, 1);
-                    const oevUpdateValue = 0;
+                    const oevUpdateValue = 105;
                     const currentTimestamp = await helpers.time.latest();
                     const oevUpdateTimestamp = currentTimestamp + 1;
                     const bidAmount = 10000;
                     const updateId = testUtils.generateRandomBytes32();
-                    // Randomly omit one of the signatures
-                    const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                    // Randomly omit two of the signatures
+                    const includeSignatureAtIndex = Math.floor(Math.random() * beacons.length);
                     const signatures = await Promise.all(
                       beacons.map(async (beacon, index) => {
-                        if (index === omitSignatureAtIndex) {
+                        if (index !== includeSignatureAtIndex) {
                           return '0x';
                         } else {
-                          return '0x123456';
+                          return await testUtils.signOevData(
+                            dataFeedServerFull,
+                            oevProxy.address,
+                            beaconSet.beaconSetId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            roles.searcher.address,
+                            bidAmount,
+                            beacon.airnode.wallet,
+                            beacon.templateId
+                          );
                         }
                       })
                     );
@@ -4812,135 +3347,90 @@ describe('DataFeedServerFull', function () {
                           packedOevUpdateSignatures,
                           { value: bidAmount }
                         )
-                    ).to.be.revertedWith('ECDSA: invalid signature length');
+                    ).to.be.revertedWith('Not enough signatures');
                   });
                 });
               });
-              context('One Beacon is specified', function () {
-                context('The signature is not invalid', function () {
-                  context('The signature is not omitted', function () {
-                    context('Data in the packed signature is consistent with the data feed ID', function () {
-                      it('updates OEV proxy Beacon with signed data', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const signature = await testUtils.signOevData(
-                          dataFeedServerFull,
-                          oevProxy.address,
-                          beacon.beaconId,
-                          updateId,
-                          oevUpdateTimestamp,
-                          encodeData(oevUpdateValue),
-                          roles.searcher.address,
-                          bidAmount,
-                          beacon.airnode.wallet,
-                          beacon.templateId
-                        );
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          signature
-                        );
-                        const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                        expect(beaconBefore.value).to.equal(1);
-                        expect(beaconBefore.timestamp).to.equal(1);
-                        const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beacon.beaconId
-                        );
-                        expect(oevProxyBeaconBefore.value).to.equal(0);
-                        expect(oevProxyBeaconBefore.timestamp).to.equal(0);
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              beacon.beaconId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        )
-                          .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconWithSignedData')
-                          .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
-                        const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
-                        expect(beaconAfter.value).to.equal(1);
-                        expect(beaconAfter.timestamp).to.equal(1);
-                        const oevProxyBeaconAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
-                          oevProxy.address,
-                          beacon.beaconId
-                        );
-                        expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
-                        expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
-                      });
-                    });
-                    context('Data in the packed signature is not consistent with the data feed ID', function () {
-                      it('reverts', async function () {
-                        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
-                        const beacon = beacons[0];
-                        const spoofedDataFeedId = beacons[1].beaconId;
-                        await updateBeacon(roles, dataFeedServerFull, beacons[1], 1, 1);
-                        await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
-                        const oevUpdateValue = 0;
-                        const currentTimestamp = await helpers.time.latest();
-                        const oevUpdateTimestamp = currentTimestamp + 1;
-                        const bidAmount = 10000;
-                        const updateId = testUtils.generateRandomBytes32();
-                        const signature = await testUtils.signOevData(
-                          dataFeedServerFull,
-                          oevProxy.address,
-                          spoofedDataFeedId,
-                          updateId,
-                          oevUpdateTimestamp,
-                          encodeData(oevUpdateValue),
-                          roles.searcher.address,
-                          bidAmount,
-                          beacon.airnode.wallet,
-                          beacon.templateId
-                        );
-                        const packedOevUpdateSignature = packOevUpdateSignature(
-                          beacon.airnode.wallet.address,
-                          beacon.templateId,
-                          signature
-                        );
-                        await expect(
-                          dataFeedServerFull
-                            .connect(roles.searcher)
-                            .updateOevProxyDataFeedWithSignedData(
-                              oevProxy.address,
-                              spoofedDataFeedId,
-                              updateId,
-                              oevUpdateTimestamp,
-                              encodeData(oevUpdateValue),
-                              [packedOevUpdateSignature],
-                              { value: bidAmount }
-                            )
-                        ).to.be.revertedWith('Beacon ID mismatch');
-                      });
-                    });
+              context('There are invalid signatures', function () {
+                it('reverts', async function () {
+                  const { roles, dataFeedServerFull, oevProxy, beacons, beaconSet } = await deploy();
+                  const oevUpdateValue = 105;
+                  const currentTimestamp = await helpers.time.latest();
+                  const oevUpdateTimestamp = currentTimestamp + 1;
+                  const bidAmount = 10000;
+                  const updateId = testUtils.generateRandomBytes32();
+                  // Randomly omit one of the signatures
+                  const omitSignatureAtIndex = Math.floor(Math.random() * beacons.length);
+                  const signatures = await Promise.all(
+                    beacons.map(async (beacon, index) => {
+                      if (index === omitSignatureAtIndex) {
+                        return '0x';
+                      } else {
+                        return '0x123456';
+                      }
+                    })
+                  );
+                  const packedOevUpdateSignatures = signatures.map((signature, index) => {
+                    return packOevUpdateSignature(
+                      beacons[index].airnode.wallet.address,
+                      beacons[index].templateId,
+                      signature
+                    );
                   });
-                  context('The signature is omitted', function () {
-                    it('reverts', async function () {
+                  await expect(
+                    dataFeedServerFull
+                      .connect(roles.searcher)
+                      .updateOevProxyDataFeedWithSignedData(
+                        oevProxy.address,
+                        beaconSet.beaconSetId,
+                        updateId,
+                        oevUpdateTimestamp,
+                        encodeData(oevUpdateValue),
+                        packedOevUpdateSignatures,
+                        { value: bidAmount }
+                      )
+                  ).to.be.revertedWith('ECDSA: invalid signature length');
+                });
+              });
+            });
+            context('One Beacon is specified', function () {
+              context('The signature is not invalid', function () {
+                context('The signature is not omitted', function () {
+                  context('Data in the packed signature is consistent with the data feed ID', function () {
+                    it('updates OEV proxy Beacon with signed data', async function () {
                       const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                       const beacon = beacons[0];
-                      await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
-                      const oevUpdateValue = 0;
+                      const oevUpdateValue = 105;
                       const currentTimestamp = await helpers.time.latest();
                       const oevUpdateTimestamp = currentTimestamp + 1;
                       const bidAmount = 10000;
                       const updateId = testUtils.generateRandomBytes32();
+                      const signature = await testUtils.signOevData(
+                        dataFeedServerFull,
+                        oevProxy.address,
+                        beacon.beaconId,
+                        updateId,
+                        oevUpdateTimestamp,
+                        encodeData(oevUpdateValue),
+                        roles.searcher.address,
+                        bidAmount,
+                        beacon.airnode.wallet,
+                        beacon.templateId
+                      );
                       const packedOevUpdateSignature = packOevUpdateSignature(
                         beacon.airnode.wallet.address,
                         beacon.templateId,
-                        '0x'
+                        signature
                       );
+                      const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                      expect(beaconBefore.value).to.equal(0);
+                      expect(beaconBefore.timestamp).to.equal(0);
+                      const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beacon.beaconId
+                      );
+                      expect(oevProxyBeaconBefore.value).to.equal(0);
+                      expect(oevProxyBeaconBefore.timestamp).to.equal(0);
                       await expect(
                         dataFeedServerFull
                           .connect(roles.searcher)
@@ -4953,16 +3443,77 @@ describe('DataFeedServerFull', function () {
                             [packedOevUpdateSignature],
                             { value: bidAmount }
                           )
-                      ).to.be.revertedWith('Missing signature');
+                      )
+                        .to.emit(dataFeedServerFull, 'UpdatedOevProxyBeaconWithSignedData')
+                        .withArgs(beacon.beaconId, oevProxy.address, updateId, oevUpdateValue, oevUpdateTimestamp);
+                      const beaconAfter = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                      expect(beaconAfter.value).to.equal(0);
+                      expect(beaconAfter.timestamp).to.equal(0);
+                      const oevProxyBeaconAfter = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beacon.beaconId
+                      );
+                      expect(oevProxyBeaconAfter.value).to.equal(oevUpdateValue);
+                      expect(oevProxyBeaconAfter.timestamp).to.equal(oevUpdateTimestamp);
+                    });
+                  });
+                  context('Data in the packed signature is not consistent with the data feed ID', function () {
+                    it('reverts', async function () {
+                      const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+                      const beacon = beacons[0];
+                      const oevUpdateValue = 105;
+                      const currentTimestamp = await helpers.time.latest();
+                      const oevUpdateTimestamp = currentTimestamp + 1;
+                      const bidAmount = 10000;
+                      const updateId = testUtils.generateRandomBytes32();
+                      const spoofedDataFeedId = testUtils.generateRandomBytes32();
+                      const signature = await testUtils.signOevData(
+                        dataFeedServerFull,
+                        oevProxy.address,
+                        spoofedDataFeedId,
+                        updateId,
+                        oevUpdateTimestamp,
+                        encodeData(oevUpdateValue),
+                        roles.searcher.address,
+                        bidAmount,
+                        beacon.airnode.wallet,
+                        beacon.templateId
+                      );
+                      const packedOevUpdateSignature = packOevUpdateSignature(
+                        beacon.airnode.wallet.address,
+                        beacon.templateId,
+                        signature
+                      );
+                      const beaconBefore = await dataFeedServerFull.dataFeeds(beacon.beaconId);
+                      expect(beaconBefore.value).to.equal(0);
+                      expect(beaconBefore.timestamp).to.equal(0);
+                      const oevProxyBeaconBefore = await dataFeedServerFull.oevProxyToIdToDataFeed(
+                        oevProxy.address,
+                        beacon.beaconId
+                      );
+                      expect(oevProxyBeaconBefore.value).to.equal(0);
+                      expect(oevProxyBeaconBefore.timestamp).to.equal(0);
+                      await expect(
+                        dataFeedServerFull
+                          .connect(roles.searcher)
+                          .updateOevProxyDataFeedWithSignedData(
+                            oevProxy.address,
+                            spoofedDataFeedId,
+                            updateId,
+                            oevUpdateTimestamp,
+                            encodeData(oevUpdateValue),
+                            [packedOevUpdateSignature],
+                            { value: bidAmount }
+                          )
+                      ).to.be.revertedWith('Beacon ID mismatch');
                     });
                   });
                 });
-                context('The signature is invalid', function () {
+                context('The signature is omitted', function () {
                   it('reverts', async function () {
                     const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                     const beacon = beacons[0];
-                    await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
-                    const oevUpdateValue = 0;
+                    const oevUpdateValue = 105;
                     const currentTimestamp = await helpers.time.latest();
                     const oevUpdateTimestamp = currentTimestamp + 1;
                     const bidAmount = 10000;
@@ -4970,7 +3521,7 @@ describe('DataFeedServerFull', function () {
                     const packedOevUpdateSignature = packOevUpdateSignature(
                       beacon.airnode.wallet.address,
                       beacon.templateId,
-                      '0x123456'
+                      '0x'
                     );
                     await expect(
                       dataFeedServerFull
@@ -4984,20 +3535,24 @@ describe('DataFeedServerFull', function () {
                           [packedOevUpdateSignature],
                           { value: bidAmount }
                         )
-                    ).to.be.revertedWith('ECDSA: invalid signature length');
+                    ).to.be.revertedWith('Missing signature');
                   });
                 });
               });
-              context('No Beacon is specified', function () {
+              context('The signature is invalid', function () {
                 it('reverts', async function () {
                   const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                   const beacon = beacons[0];
-                  await updateBeacon(roles, dataFeedServerFull, beacon, 1, 1);
-                  const oevUpdateValue = 0;
+                  const oevUpdateValue = 105;
                   const currentTimestamp = await helpers.time.latest();
                   const oevUpdateTimestamp = currentTimestamp + 1;
                   const bidAmount = 10000;
                   const updateId = testUtils.generateRandomBytes32();
+                  const packedOevUpdateSignature = packOevUpdateSignature(
+                    beacon.airnode.wallet.address,
+                    beacon.templateId,
+                    '0x123456'
+                  );
                   await expect(
                     dataFeedServerFull
                       .connect(roles.searcher)
@@ -5007,18 +3562,18 @@ describe('DataFeedServerFull', function () {
                         updateId,
                         oevUpdateTimestamp,
                         encodeData(oevUpdateValue),
-                        [],
+                        [packedOevUpdateSignature],
                         { value: bidAmount }
                       )
-                  ).to.be.revertedWith('Did not specify any Beacons');
+                  ).to.be.revertedWith('ECDSA: invalid signature length');
                 });
               });
             });
-            context('Updated value same as base feed value', function () {
+            context('No Beacon is specified', function () {
               it('reverts', async function () {
                 const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
                 const beacon = beacons[0];
-                const oevUpdateValue = 0;
+                const oevUpdateValue = 105;
                 const currentTimestamp = await helpers.time.latest();
                 const oevUpdateTimestamp = currentTimestamp + 1;
                 const bidAmount = 10000;
@@ -5035,47 +3590,36 @@ describe('DataFeedServerFull', function () {
                       [],
                       { value: bidAmount }
                     )
-                ).to.be.revertedWith('Repeats base feed update');
+                ).to.be.revertedWith('Did not specify any Beacons');
               });
             });
           });
-          context('Does not update timestamp', function () {
+          context('Decoded fulfillment data cannot be typecasted into int224', function () {
             it('reverts', async function () {
               const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
               const beacon = beacons[0];
-              const oevUpdateValue = 105;
+              const oevUpdateValueWithUnderflow = ethers.BigNumber.from(-2).pow(223).sub(1);
               const currentTimestamp = await helpers.time.latest();
               const oevUpdateTimestamp = currentTimestamp + 1;
               const bidAmount = 10000;
               const updateId = testUtils.generateRandomBytes32();
-              const signature = await testUtils.signOevData(
+              const signatureWithUnderflow = await testUtils.signOevData(
                 dataFeedServerFull,
                 oevProxy.address,
                 beacon.beaconId,
                 updateId,
                 oevUpdateTimestamp,
-                encodeData(oevUpdateValue),
+                encodeData(oevUpdateValueWithUnderflow),
                 roles.searcher.address,
                 bidAmount,
                 beacon.airnode.wallet,
                 beacon.templateId
               );
-              const packedOevUpdateSignature = packOevUpdateSignature(
+              const packedOevUpdateSignatureWithUnderflow = packOevUpdateSignature(
                 beacon.airnode.wallet.address,
                 beacon.templateId,
-                signature
+                signatureWithUnderflow
               );
-              await dataFeedServerFull
-                .connect(roles.searcher)
-                .updateOevProxyDataFeedWithSignedData(
-                  oevProxy.address,
-                  beacon.beaconId,
-                  updateId,
-                  oevUpdateTimestamp,
-                  encodeData(oevUpdateValue),
-                  [packedOevUpdateSignature],
-                  { value: bidAmount }
-                );
               await expect(
                 dataFeedServerFull
                   .connect(roles.searcher)
@@ -5084,39 +3628,70 @@ describe('DataFeedServerFull', function () {
                     beacon.beaconId,
                     updateId,
                     oevUpdateTimestamp,
-                    encodeData(oevUpdateValue),
-                    [packedOevUpdateSignature],
+                    encodeData(oevUpdateValueWithUnderflow),
+                    [packedOevUpdateSignatureWithUnderflow],
                     { value: bidAmount }
                   )
-              ).to.be.revertedWith('Does not update timestamp');
+              ).to.be.revertedWith('Value typecasting error');
+              const oevUpdateValueWithOverflow = ethers.BigNumber.from(2).pow(223);
+              const signatureWithOverflow = await testUtils.signOevData(
+                dataFeedServerFull,
+                oevProxy.address,
+                beacon.beaconId,
+                updateId,
+                oevUpdateTimestamp,
+                encodeData(oevUpdateValueWithOverflow),
+                roles.searcher.address,
+                bidAmount,
+                beacon.airnode.wallet,
+                beacon.templateId
+              );
+              const packedOevUpdateSignatureWithOverflow = packOevUpdateSignature(
+                beacon.airnode.wallet.address,
+                beacon.templateId,
+                signatureWithOverflow
+              );
+              await expect(
+                dataFeedServerFull
+                  .connect(roles.searcher)
+                  .updateOevProxyDataFeedWithSignedData(
+                    oevProxy.address,
+                    beacon.beaconId,
+                    updateId,
+                    oevUpdateTimestamp,
+                    encodeData(oevUpdateValueWithOverflow),
+                    [packedOevUpdateSignatureWithOverflow],
+                    { value: bidAmount }
+                  )
+              ).to.be.revertedWith('Value typecasting error');
             });
           });
         });
-        context('Decoded fulfillment data cannot be typecasted into int224', function () {
+        context('Fulfillment data length is not correct', function () {
           it('reverts', async function () {
             const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
             const beacon = beacons[0];
-            const oevUpdateValueWithUnderflow = ethers.BigNumber.from(-2).pow(223).sub(1);
+            const oevUpdateValue = 105;
             const currentTimestamp = await helpers.time.latest();
             const oevUpdateTimestamp = currentTimestamp + 1;
             const bidAmount = 10000;
             const updateId = testUtils.generateRandomBytes32();
-            const signatureWithUnderflow = await testUtils.signOevData(
+            const signature = await testUtils.signOevData(
               dataFeedServerFull,
               oevProxy.address,
               beacon.beaconId,
               updateId,
               oevUpdateTimestamp,
-              encodeData(oevUpdateValueWithUnderflow),
+              encodeData(oevUpdateValue) + '00',
               roles.searcher.address,
               bidAmount,
               beacon.airnode.wallet,
               beacon.templateId
             );
-            const packedOevUpdateSignatureWithUnderflow = packOevUpdateSignature(
+            const packedOevUpdateSignature = packOevUpdateSignature(
               beacon.airnode.wallet.address,
               beacon.templateId,
-              signatureWithUnderflow
+              signature
             );
             await expect(
               dataFeedServerFull
@@ -5126,46 +3701,15 @@ describe('DataFeedServerFull', function () {
                   beacon.beaconId,
                   updateId,
                   oevUpdateTimestamp,
-                  encodeData(oevUpdateValueWithUnderflow),
-                  [packedOevUpdateSignatureWithUnderflow],
+                  encodeData(oevUpdateValue) + '00',
+                  [packedOevUpdateSignature],
                   { value: bidAmount }
                 )
-            ).to.be.revertedWith('Value typecasting error');
-            const oevUpdateValueWithOverflow = ethers.BigNumber.from(2).pow(223);
-            const signatureWithOverflow = await testUtils.signOevData(
-              dataFeedServerFull,
-              oevProxy.address,
-              beacon.beaconId,
-              updateId,
-              oevUpdateTimestamp,
-              encodeData(oevUpdateValueWithOverflow),
-              roles.searcher.address,
-              bidAmount,
-              beacon.airnode.wallet,
-              beacon.templateId
-            );
-            const packedOevUpdateSignatureWithOverflow = packOevUpdateSignature(
-              beacon.airnode.wallet.address,
-              beacon.templateId,
-              signatureWithOverflow
-            );
-            await expect(
-              dataFeedServerFull
-                .connect(roles.searcher)
-                .updateOevProxyDataFeedWithSignedData(
-                  oevProxy.address,
-                  beacon.beaconId,
-                  updateId,
-                  oevUpdateTimestamp,
-                  encodeData(oevUpdateValueWithOverflow),
-                  [packedOevUpdateSignatureWithOverflow],
-                  { value: bidAmount }
-                )
-            ).to.be.revertedWith('Value typecasting error');
+            ).to.be.revertedWith('Data length not correct');
           });
         });
       });
-      context('Fulfillment data length is not correct', function () {
+      context('Does not update timestamp', function () {
         it('reverts', async function () {
           const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
           const beacon = beacons[0];
@@ -5180,7 +3724,7 @@ describe('DataFeedServerFull', function () {
             beacon.beaconId,
             updateId,
             oevUpdateTimestamp,
-            encodeData(oevUpdateValue) + '00',
+            encodeData(oevUpdateValue),
             roles.searcher.address,
             bidAmount,
             beacon.airnode.wallet,
@@ -5191,6 +3735,17 @@ describe('DataFeedServerFull', function () {
             beacon.templateId,
             signature
           );
+          await dataFeedServerFull
+            .connect(roles.searcher)
+            .updateOevProxyDataFeedWithSignedData(
+              oevProxy.address,
+              beacon.beaconId,
+              updateId,
+              oevUpdateTimestamp,
+              encodeData(oevUpdateValue),
+              [packedOevUpdateSignature],
+              { value: bidAmount }
+            );
           await expect(
             dataFeedServerFull
               .connect(roles.searcher)
@@ -5199,11 +3754,11 @@ describe('DataFeedServerFull', function () {
                 beacon.beaconId,
                 updateId,
                 oevUpdateTimestamp,
-                encodeData(oevUpdateValue) + '00',
+                encodeData(oevUpdateValue),
                 [packedOevUpdateSignature],
                 { value: bidAmount }
               )
-          ).to.be.revertedWith('Data length not correct');
+          ).to.be.revertedWith('Does not update timestamp');
         });
       });
     });
@@ -5232,6 +3787,20 @@ describe('DataFeedServerFull', function () {
         ).to.be.revertedWith('Timestamp not valid');
       });
     });
+    context('Timestamp is zero', function () {
+      it('reverts', async function () {
+        const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
+        const bidAmount = 10000;
+        const updateId = testUtils.generateRandomBytes32();
+        await expect(
+          dataFeedServerFull
+            .connect(roles.searcher)
+            .updateOevProxyDataFeedWithSignedData(oevProxy.address, updateId, beacons[0].beaconId, 0, '0x', ['0x'], {
+              value: bidAmount,
+            })
+        ).to.be.revertedWith('Does not update timestamp');
+      });
+    });
   });
 
   describe('withdraw', function () {
@@ -5242,7 +3811,7 @@ describe('DataFeedServerFull', function () {
             it('withdraws the OEV proxy balance to the respective beneficiary', async function () {
               const { roles, dataFeedServerFull, oevProxy, beacons } = await deploy();
               const beacon = beacons[0];
-              const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+              const beaconValue = Math.floor(Math.random() * 200 - 100);
               const beaconTimestamp = await helpers.time.latest();
               const bidAmount = 10000;
               const updateId = testUtils.generateRandomBytes32();
@@ -5303,7 +3872,7 @@ describe('DataFeedServerFull', function () {
                 beacon.beaconId,
                 dataFeedServerFull.address
               );
-              const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+              const beaconValue = Math.floor(Math.random() * 200 - 100);
               const beaconTimestamp = await helpers.time.latest();
               const bidAmount = 10000;
               const updateId = testUtils.generateRandomBytes32();
@@ -5473,7 +4042,7 @@ describe('DataFeedServerFull', function () {
       it('reads data feed', async function () {
         const { roles, dataFeedServerFull, beacons } = await deploy();
         const beacon = beacons[0];
-        const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+        const beaconValue = Math.floor(Math.random() * 200 - 100);
         const beaconTimestamp = await helpers.time.latest();
         await updateBeacon(roles, dataFeedServerFull, beacon, beaconValue, beaconTimestamp);
         const beaconAfter = await dataFeedServerFull.connect(roles.randomPerson).readDataFeedWithId(beacon.beaconId);
@@ -5498,7 +4067,7 @@ describe('DataFeedServerFull', function () {
         it('reads Beacon', async function () {
           const { roles, dataFeedServerFull, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           await updateBeacon(roles, dataFeedServerFull, beacon, beaconValue, beaconTimestamp);
           const dapiName = ethers.utils.formatBytes32String('My dAPI');
@@ -5528,7 +4097,7 @@ describe('DataFeedServerFull', function () {
       context('Data feed is initialized', function () {
         it('reads Beacon set', async function () {
           const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
-          const beaconSetValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconSetValue = Math.floor(Math.random() * 200 - 100);
           const beaconSetTimestamp = await helpers.time.latest();
           await updateBeaconSet(roles, dataFeedServerFull, beacons, beaconSetValue, beaconSetTimestamp);
           const dapiName = ethers.utils.formatBytes32String('My dAPI');
@@ -5571,7 +4140,7 @@ describe('DataFeedServerFull', function () {
         it('reads OEV proxy data feed', async function () {
           const { roles, dataFeedServerFull, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           const bidAmount = 10000;
           const updateId = testUtils.generateRandomBytes32();
@@ -5616,7 +4185,7 @@ describe('DataFeedServerFull', function () {
         it('reads base data feed', async function () {
           const { roles, dataFeedServerFull, beacons } = await deploy();
           const beacon = beacons[0];
-          const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+          const beaconValue = Math.floor(Math.random() * 200 - 100);
           const beaconTimestamp = await helpers.time.latest();
           await updateBeacon(roles, dataFeedServerFull, beacon, beaconValue, beaconTimestamp);
           const beaconAfter = await dataFeedServerFull
@@ -5645,7 +4214,7 @@ describe('DataFeedServerFull', function () {
           it('reads OEV proxy data feed', async function () {
             const { roles, dataFeedServerFull, beacons } = await deploy();
             const beacon = beacons[0];
-            const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconValue = Math.floor(Math.random() * 200 - 100);
             const beaconTimestamp = await helpers.time.latest();
             const bidAmount = 10000;
             const updateId = testUtils.generateRandomBytes32();
@@ -5693,7 +4262,7 @@ describe('DataFeedServerFull', function () {
           it('reads base data feed', async function () {
             const { roles, dataFeedServerFull, beacons } = await deploy();
             const beacon = beacons[0];
-            const beaconValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconValue = Math.floor(Math.random() * 200 - 100);
             const beaconTimestamp = await helpers.time.latest();
             await updateBeacon(roles, dataFeedServerFull, beacon, beaconValue, beaconTimestamp);
             const dapiName = ethers.utils.formatBytes32String('My dAPI');
@@ -5797,7 +4366,7 @@ describe('DataFeedServerFull', function () {
           it('reads base data feed', async function () {
             const { roles, dataFeedServerFull, beacons, beaconSet } = await deploy();
             const currentTimestamp = await helpers.time.latest();
-            const beaconSetValue = Math.floor(Math.random() * 20000 - 10000);
+            const beaconSetValue = Math.floor(Math.random() * 200 - 100);
             const beaconSetTimestamp = Math.floor(currentTimestamp - Math.random() * 5 * 60);
             await updateBeaconSet(roles, dataFeedServerFull, beacons, beaconSetValue, beaconSetTimestamp);
             const dapiName = ethers.utils.formatBytes32String('My dAPI');


### PR DESCRIPTION
Based on our call yesterday, reverts the changes to go back to the state at https://github.com/api3dao/airnode-protocol-v1/tree/a36cadbdce4e031f761bb99701e1d5f254dd6316

As such, the only post-audit changes are:
- Added `containsBytecode()` https://github.com/api3dao/airnode-protocol-v1/commit/6d152925cc2ae716103d7360048133d5c67e0ead
- Removed PSP Beacon set updates from Api3ServerV1 https://github.com/api3dao/airnode-protocol-v1/commit/6d38d5ff433726cd7a20ffa118e8a6c809bb4edb
- OwnableCallForwarder constructor gets the owner address as an argument (we already use this version in manager-multisig) https://github.com/api3dao/airnode-protocol-v1/commit/d5d1310297d9e9b9a7f61340c063d042dd05bfaa