### PR TITLE
Rename DapiServer as Api3ServerV1 in proxies and factory

### DIFF
--- a/contracts/dapis/proxies/DapiProxy.sol
+++ b/contracts/dapis/proxies/DapiProxy.sol
@@ -5,7 +5,7 @@ import "./interfaces/IDapiProxy.sol";
 import "../interfaces/IApi3ServerV1.sol";
 
 /// @title An immutable proxy contract that is used to read a specific dAPI of
-/// a specific DapiServer contract
+/// a specific Api3ServerV1 contract
 /// @notice In an effort to reduce the bytecode of this contract, its
 /// constructor arguments are validated by ProxyFactory, rather than
 /// internally. If you intend to deploy this contract without using
@@ -26,15 +26,15 @@ import "../interfaces/IApi3ServerV1.sol";
 /// off-chain value that is being reported, similar to `value`. Both should
 /// only be trusted as much as the Airnode(s) that report them.
 contract DapiProxy is IDapiProxy {
-    /// @notice DapiServer address
-    address public immutable override dapiServer;
+    /// @notice Api3ServerV1 address
+    address public immutable override api3ServerV1;
     /// @notice Hash of the dAPI name
     bytes32 public immutable override dapiNameHash;
 
-    /// @param _dapiServer DapiServer address
+    /// @param _api3ServerV1 Api3ServerV1 address
     /// @param _dapiNameHash Hash of the dAPI name
-    constructor(address _dapiServer, bytes32 _dapiNameHash) {
-        dapiServer = _dapiServer;
+    constructor(address _api3ServerV1, bytes32 _dapiNameHash) {
+        api3ServerV1 = _api3ServerV1;
         dapiNameHash = _dapiNameHash;
     }
 
@@ -48,7 +48,7 @@ contract DapiProxy is IDapiProxy {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (value, timestamp) = IApi3ServerV1(dapiServer)
+        (value, timestamp) = IApi3ServerV1(api3ServerV1)
             .readDataFeedWithDapiNameHash(dapiNameHash);
     }
 }

--- a/contracts/dapis/proxies/DapiProxyWithOev.sol
+++ b/contracts/dapis/proxies/DapiProxyWithOev.sol
@@ -5,8 +5,8 @@ import "./DapiProxy.sol";
 import "./interfaces/IOevProxy.sol";
 
 /// @title An immutable proxy contract that is used to read a specific dAPI of
-/// a specific DapiServer contract and inform DapiServer about the beneficiary
-/// of the respective OEV proceeds
+/// a specific Api3ServerV1 contract and inform Api3ServerV1 about the
+/// beneficiary of the respective OEV proceeds
 /// @notice In an effort to reduce the bytecode of this contract, its
 /// constructor arguments are validated by ProxyFactory, rather than
 /// internally. If you intend to deploy this contract without using
@@ -16,14 +16,14 @@ contract DapiProxyWithOev is DapiProxy, IOevProxy {
     /// @notice OEV beneficiary address
     address public immutable override oevBeneficiary;
 
-    /// @param _dapiServer DapiServer address
+    /// @param _api3ServerV1 Api3ServerV1 address
     /// @param _dapiNameHash Hash of the dAPI name
     /// @param _oevBeneficiary OEV beneficiary
     constructor(
-        address _dapiServer,
+        address _api3ServerV1,
         bytes32 _dapiNameHash,
         address _oevBeneficiary
-    ) DapiProxy(_dapiServer, _dapiNameHash) {
+    ) DapiProxy(_api3ServerV1, _dapiNameHash) {
         oevBeneficiary = _oevBeneficiary;
     }
 
@@ -37,7 +37,7 @@ contract DapiProxyWithOev is DapiProxy, IOevProxy {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (value, timestamp) = IApi3ServerV1(dapiServer)
+        (value, timestamp) = IApi3ServerV1(api3ServerV1)
             .readDataFeedWithDapiNameHashAsOevProxy(dapiNameHash);
     }
 }

--- a/contracts/dapis/proxies/DataFeedProxy.sol
+++ b/contracts/dapis/proxies/DataFeedProxy.sol
@@ -5,22 +5,22 @@ import "./interfaces/IDataFeedProxy.sol";
 import "../interfaces/IApi3ServerV1.sol";
 
 /// @title An immutable proxy contract that is used to read a specific data
-/// feed (Beacon or Beacon set) of a specific DapiServer contract
+/// feed (Beacon or Beacon set) of a specific Api3ServerV1 contract
 /// @notice In an effort to reduce the bytecode of this contract, its
 /// constructor arguments are validated by ProxyFactory, rather than
 /// internally. If you intend to deploy this contract without using
 /// ProxyFactory, you are recommended to implement an equivalent validation.
 /// @dev See DapiProxy.sol for comments about usage
 contract DataFeedProxy is IDataFeedProxy {
-    /// @notice DapiServer address
-    address public immutable override dapiServer;
+    /// @notice Api3ServerV1 address
+    address public immutable override api3ServerV1;
     /// @notice Data feed ID
     bytes32 public immutable override dataFeedId;
 
-    /// @param _dapiServer DapiServer address
+    /// @param _api3ServerV1 Api3ServerV1 address
     /// @param _dataFeedId Data feed (Beacon or Beacon set) ID
-    constructor(address _dapiServer, bytes32 _dataFeedId) {
-        dapiServer = _dapiServer;
+    constructor(address _api3ServerV1, bytes32 _dataFeedId) {
+        api3ServerV1 = _api3ServerV1;
         dataFeedId = _dataFeedId;
     }
 
@@ -34,7 +34,7 @@ contract DataFeedProxy is IDataFeedProxy {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (value, timestamp) = IApi3ServerV1(dapiServer).readDataFeedWithId(
+        (value, timestamp) = IApi3ServerV1(api3ServerV1).readDataFeedWithId(
             dataFeedId
         );
     }

--- a/contracts/dapis/proxies/DataFeedProxyWithOev.sol
+++ b/contracts/dapis/proxies/DataFeedProxyWithOev.sol
@@ -5,8 +5,8 @@ import "./DataFeedProxy.sol";
 import "./interfaces/IOevProxy.sol";
 
 /// @title An immutable proxy contract that is used to read a specific data
-/// feed (Beacon or Beacon set) of a specific DapiServer contract and inform
-/// DapiServer about the beneficiary of the respective OEV proceeds
+/// feed (Beacon or Beacon set) of a specific Api3ServerV1 contract and inform
+/// Api3ServerV1 about the beneficiary of the respective OEV proceeds
 /// @notice In an effort to reduce the bytecode of this contract, its
 /// constructor arguments are validated by ProxyFactory, rather than
 /// internally. If you intend to deploy this contract without using
@@ -16,14 +16,14 @@ contract DataFeedProxyWithOev is DataFeedProxy, IOevProxy {
     /// @notice OEV beneficiary address
     address public immutable override oevBeneficiary;
 
-    /// @param _dapiServer DapiServer address
+    /// @param _api3ServerV1 Api3ServerV1 address
     /// @param _dataFeedId Data feed (Beacon or Beacon set) ID
     /// @param _oevBeneficiary OEV beneficiary
     constructor(
-        address _dapiServer,
+        address _api3ServerV1,
         bytes32 _dataFeedId,
         address _oevBeneficiary
-    ) DataFeedProxy(_dapiServer, _dataFeedId) {
+    ) DataFeedProxy(_api3ServerV1, _dataFeedId) {
         oevBeneficiary = _oevBeneficiary;
     }
 
@@ -37,7 +37,7 @@ contract DataFeedProxyWithOev is DataFeedProxy, IOevProxy {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (value, timestamp) = IApi3ServerV1(dapiServer)
+        (value, timestamp) = IApi3ServerV1(api3ServerV1)
             .readDataFeedWithIdAsOevProxy(dataFeedId);
     }
 }

--- a/contracts/dapis/proxies/ProxyFactory.sol
+++ b/contracts/dapis/proxies/ProxyFactory.sol
@@ -13,13 +13,13 @@ import "./interfaces/IProxyFactory.sol";
 /// @dev The proxies are deployed normally and not cloned to minimize the gas
 /// cost overhead while using them to read data feed values
 contract ProxyFactory is IProxyFactory {
-    /// @notice DapiServer address
-    address public immutable override dapiServer;
+    /// @notice Api3ServerV1 address
+    address public immutable override api3ServerV1;
 
-    /// @param _dapiServer DapiServer address
-    constructor(address _dapiServer) {
-        require(_dapiServer != address(0), "DapiServer address zero");
-        dapiServer = _dapiServer;
+    /// @param _api3ServerV1 Api3ServerV1 address
+    constructor(address _api3ServerV1) {
+        require(_api3ServerV1 != address(0), "Api3ServerV1 address zero");
+        api3ServerV1 = _api3ServerV1;
     }
 
     /// @notice Deterministically deploys a data feed proxy
@@ -32,7 +32,10 @@ contract ProxyFactory is IProxyFactory {
     ) external override returns (address proxyAddress) {
         require(dataFeedId != bytes32(0), "Data feed ID zero");
         proxyAddress = address(
-            new DataFeedProxy{salt: keccak256(metadata)}(dapiServer, dataFeedId)
+            new DataFeedProxy{salt: keccak256(metadata)}(
+                api3ServerV1,
+                dataFeedId
+            )
         );
         emit DeployedDataFeedProxy(proxyAddress, dataFeedId, metadata);
     }
@@ -48,7 +51,7 @@ contract ProxyFactory is IProxyFactory {
         require(dapiName != bytes32(0), "dAPI name zero");
         proxyAddress = address(
             new DapiProxy{salt: keccak256(metadata)}(
-                dapiServer,
+                api3ServerV1,
                 keccak256(abi.encodePacked(dapiName))
             )
         );
@@ -69,7 +72,7 @@ contract ProxyFactory is IProxyFactory {
         require(oevBeneficiary != address(0), "OEV beneficiary zero");
         proxyAddress = address(
             new DataFeedProxyWithOev{salt: keccak256(metadata)}(
-                dapiServer,
+                api3ServerV1,
                 dataFeedId,
                 oevBeneficiary
             )
@@ -96,7 +99,7 @@ contract ProxyFactory is IProxyFactory {
         require(oevBeneficiary != address(0), "OEV beneficiary zero");
         proxyAddress = address(
             new DapiProxyWithOev{salt: keccak256(metadata)}(
-                dapiServer,
+                api3ServerV1,
                 keccak256(abi.encodePacked(dapiName)),
                 oevBeneficiary
             )

--- a/contracts/dapis/proxies/interfaces/IProxy.sol
+++ b/contracts/dapis/proxies/interfaces/IProxy.sol
@@ -5,5 +5,5 @@ pragma solidity ^0.8.0;
 interface IProxy {
     function read() external view returns (int224 value, uint32 timestamp);
 
-    function dapiServer() external view returns (address);
+    function api3ServerV1() external view returns (address);
 }

--- a/contracts/dapis/proxies/interfaces/IProxyFactory.sol
+++ b/contracts/dapis/proxies/interfaces/IProxyFactory.sol
@@ -50,5 +50,5 @@ interface IProxyFactory {
         bytes calldata metadata
     ) external returns (address proxyAddress);
 
-    function dapiServer() external view returns (address);
+    function api3ServerV1() external view returns (address);
 }

--- a/test/dapis/proxies/DapiProxyWithOev.sol.js
+++ b/test/dapis/proxies/DapiProxyWithOev.sol.js
@@ -13,21 +13,21 @@ describe('DapiProxyWithOev', function () {
       airnode: accounts[3],
       oevBeneficiary: accounts[4],
     };
-    const dapiServerAdminRoleDescription = 'DapiServer admin';
+    const api3ServerV1AdminRoleDescription = 'Api3ServerV1 admin';
     const dapiName = ethers.utils.formatBytes32String('My dAPI');
     const dapiNameHash = ethers.utils.solidityKeccak256(['bytes32'], [dapiName]);
 
     const accessControlRegistryFactory = await ethers.getContractFactory('AccessControlRegistry', roles.deployer);
     const accessControlRegistry = await accessControlRegistryFactory.deploy();
-    const dapiServerFactory = await ethers.getContractFactory('Api3ServerV1', roles.deployer);
-    const dapiServer = await dapiServerFactory.deploy(
+    const api3ServerV1Factory = await ethers.getContractFactory('Api3ServerV1', roles.deployer);
+    const api3ServerV1 = await api3ServerV1Factory.deploy(
       accessControlRegistry.address,
-      dapiServerAdminRoleDescription,
+      api3ServerV1AdminRoleDescription,
       roles.manager.address
     );
     const dapiProxyWithOevFactory = await ethers.getContractFactory('DapiProxyWithOev', roles.deployer);
     const dapiProxyWithOev = await dapiProxyWithOevFactory.deploy(
-      dapiServer.address,
+      api3ServerV1.address,
       dapiNameHash,
       roles.oevBeneficiary.address
     );
@@ -40,17 +40,17 @@ describe('DapiProxyWithOev', function () {
     const beaconId = ethers.utils.keccak256(
       ethers.utils.solidityPack(['address', 'bytes32'], [roles.airnode.address, templateId])
     );
-    await dapiServer.connect(roles.manager).setDapiName(dapiName, beaconId);
+    await api3ServerV1.connect(roles.manager).setDapiName(dapiName, beaconId);
 
     const beaconValue = 123;
     const beaconTimestamp = await helpers.time.latest();
     const data = ethers.utils.defaultAbiCoder.encode(['int256'], [beaconValue]);
     const signature = await testUtils.signData(roles.airnode, templateId, beaconTimestamp, data);
-    await dapiServer.updateBeaconWithSignedData(roles.airnode.address, templateId, beaconTimestamp, data, signature);
+    await api3ServerV1.updateBeaconWithSignedData(roles.airnode.address, templateId, beaconTimestamp, data, signature);
 
     return {
       roles,
-      dapiServer,
+      api3ServerV1,
       dapiProxyWithOev,
       dapiNameHash,
       beaconValue,
@@ -60,8 +60,8 @@ describe('DapiProxyWithOev', function () {
 
   describe('constructor', function () {
     it('constructs', async function () {
-      const { roles, dapiServer, dapiProxyWithOev, dapiNameHash } = await helpers.loadFixture(deploy);
-      expect(await dapiProxyWithOev.dapiServer()).to.equal(dapiServer.address);
+      const { roles, api3ServerV1, dapiProxyWithOev, dapiNameHash } = await helpers.loadFixture(deploy);
+      expect(await dapiProxyWithOev.api3ServerV1()).to.equal(api3ServerV1.address);
       expect(await dapiProxyWithOev.dapiNameHash()).to.equal(dapiNameHash);
       expect(await dapiProxyWithOev.oevBeneficiary()).to.equal(roles.oevBeneficiary.address);
     });
@@ -79,13 +79,15 @@ describe('DapiProxyWithOev', function () {
       });
       context('Data feed is not initialized', function () {
         it('reverts', async function () {
-          const { roles, dapiServer } = await helpers.loadFixture(deploy);
+          const { roles, api3ServerV1 } = await helpers.loadFixture(deploy);
           const uninitializedDapiName = ethers.utils.formatBytes32String('My uninitialized dAPI');
           const uninitializedDapiNameHash = ethers.utils.solidityKeccak256(['bytes32'], [uninitializedDapiName]);
-          await dapiServer.connect(roles.manager).setDapiName(uninitializedDapiName, testUtils.generateRandomBytes32());
+          await api3ServerV1
+            .connect(roles.manager)
+            .setDapiName(uninitializedDapiName, testUtils.generateRandomBytes32());
           const dapiProxyWithOevFactory = await ethers.getContractFactory('DapiProxyWithOev', roles.deployer);
           const dapiProxyWithOev = await dapiProxyWithOevFactory.deploy(
-            dapiServer.address,
+            api3ServerV1.address,
             uninitializedDapiNameHash,
             roles.oevBeneficiary.address
           );
@@ -95,12 +97,12 @@ describe('DapiProxyWithOev', function () {
     });
     context('dAPI name is not set', function () {
       it('reverts', async function () {
-        const { roles, dapiServer } = await helpers.loadFixture(deploy);
+        const { roles, api3ServerV1 } = await helpers.loadFixture(deploy);
         const unsetDapiName = ethers.utils.formatBytes32String('My unset dAPI');
         const unsetDapiNameHash = ethers.utils.solidityKeccak256(['bytes32'], [unsetDapiName]);
         const dapiProxyWithOevFactory = await ethers.getContractFactory('DapiProxyWithOev', roles.deployer);
         const dapiProxyWithOev = await dapiProxyWithOevFactory.deploy(
-          dapiServer.address,
+          api3ServerV1.address,
           unsetDapiNameHash,
           roles.oevBeneficiary.address
         );

--- a/test/dapis/proxies/DataFeedProxyWithOev.sol.js
+++ b/test/dapis/proxies/DataFeedProxyWithOev.sol.js
@@ -13,14 +13,14 @@ describe('DataFeedProxyWithOev', function () {
       airnode: accounts[3],
       oevBeneficiary: accounts[4],
     };
-    const dapiServerAdminRoleDescription = 'DapiServer admin';
+    const api3ServerV1AdminRoleDescription = 'Api3ServerV1 admin';
 
     const accessControlRegistryFactory = await ethers.getContractFactory('AccessControlRegistry', roles.deployer);
     const accessControlRegistry = await accessControlRegistryFactory.deploy();
-    const dapiServerFactory = await ethers.getContractFactory('Api3ServerV1', roles.deployer);
-    const dapiServer = await dapiServerFactory.deploy(
+    const api3ServerV1Factory = await ethers.getContractFactory('Api3ServerV1', roles.deployer);
+    const api3ServerV1 = await api3ServerV1Factory.deploy(
       accessControlRegistry.address,
-      dapiServerAdminRoleDescription,
+      api3ServerV1AdminRoleDescription,
       roles.manager.address
     );
 
@@ -37,18 +37,18 @@ describe('DataFeedProxyWithOev', function () {
     const beaconTimestamp = await helpers.time.latest();
     const data = ethers.utils.defaultAbiCoder.encode(['int256'], [beaconValue]);
     const signature = await testUtils.signData(roles.airnode, templateId, beaconTimestamp, data);
-    await dapiServer.updateBeaconWithSignedData(roles.airnode.address, templateId, beaconTimestamp, data, signature);
+    await api3ServerV1.updateBeaconWithSignedData(roles.airnode.address, templateId, beaconTimestamp, data, signature);
 
     const dataFeedProxyWithOevFactory = await ethers.getContractFactory('DataFeedProxyWithOev', roles.deployer);
     const dataFeedProxyWithOev = await dataFeedProxyWithOevFactory.deploy(
-      dapiServer.address,
+      api3ServerV1.address,
       beaconId,
       roles.oevBeneficiary.address
     );
 
     return {
       roles,
-      dapiServer,
+      api3ServerV1,
       dataFeedProxyWithOev,
       beaconId,
       beaconValue,
@@ -58,8 +58,8 @@ describe('DataFeedProxyWithOev', function () {
 
   describe('constructor', function () {
     it('constructs', async function () {
-      const { roles, dapiServer, dataFeedProxyWithOev, beaconId } = await helpers.loadFixture(deploy);
-      expect(await dataFeedProxyWithOev.dapiServer()).to.equal(dapiServer.address);
+      const { roles, api3ServerV1, dataFeedProxyWithOev, beaconId } = await helpers.loadFixture(deploy);
+      expect(await dataFeedProxyWithOev.api3ServerV1()).to.equal(api3ServerV1.address);
       expect(await dataFeedProxyWithOev.dataFeedId()).to.equal(beaconId);
       expect(await dataFeedProxyWithOev.oevBeneficiary()).to.equal(roles.oevBeneficiary.address);
     });
@@ -76,10 +76,10 @@ describe('DataFeedProxyWithOev', function () {
     });
     context('Data feed is not initialized', function () {
       it('reverts', async function () {
-        const { roles, dapiServer } = await helpers.loadFixture(deploy);
+        const { roles, api3ServerV1 } = await helpers.loadFixture(deploy);
         const dataFeedProxyWithOevFactory = await ethers.getContractFactory('DataFeedProxyWithOev', roles.deployer);
         const dataFeedProxyWithOev = await dataFeedProxyWithOevFactory.deploy(
-          dapiServer.address,
+          api3ServerV1.address,
           testUtils.generateRandomBytes32(),
           roles.oevBeneficiary.address
         );


### PR DESCRIPTION
I updated the names on @Ashar2shahid's request. I think the api3ServerV1 name (rather than something more general) makes sense in that if one ever uses a custom data feed server implementation it will most likely not use proxies, so this proxy factory is in practice Api3ServerV1 specific.