### PR TITLE
Add proxy address prediction functions

### DIFF
--- a/contracts/dapis/proxies/ProxyFactory.sol
+++ b/contracts/dapis/proxies/ProxyFactory.sol
@@ -6,6 +6,7 @@ import "./DapiProxy.sol";
 import "./DataFeedProxyWithOev.sol";
 import "./DapiProxyWithOev.sol";
 import "./interfaces/IProxyFactory.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
 
 /// @title Contract factory that deterministically deploys proxies that read
 /// data feeds (Beacons or Beacon sets) or dAPIs, along with optional OEV
@@ -109,6 +110,99 @@ contract ProxyFactory is IProxyFactory {
             dapiName,
             oevBeneficiary,
             metadata
+        );
+    }
+
+    /// @notice Predicts the address of the data feed proxy
+    /// @param dataFeedId Data feed ID
+    /// @param metadata Metadata associated with the proxy
+    /// @return proxyAddress Proxy address
+    function predictDataFeedProxyAddress(
+        bytes32 dataFeedId,
+        bytes calldata metadata
+    ) external view override returns (address proxyAddress) {
+        require(dataFeedId != bytes32(0), "Data feed ID zero");
+        proxyAddress = Create2.computeAddress(
+            keccak256(metadata),
+            keccak256(
+                abi.encodePacked(
+                    type(DataFeedProxy).creationCode,
+                    abi.encode(api3ServerV1, dataFeedId)
+                )
+            )
+        );
+    }
+
+    /// @notice Predicts the address of the dAPI proxy
+    /// @param dapiName dAPI name
+    /// @param metadata Metadata associated with the proxy
+    /// @return proxyAddress Proxy address
+    function predictDapiProxyAddress(
+        bytes32 dapiName,
+        bytes calldata metadata
+    ) external view override returns (address proxyAddress) {
+        require(dapiName != bytes32(0), "dAPI name zero");
+        proxyAddress = Create2.computeAddress(
+            keccak256(metadata),
+            keccak256(
+                abi.encodePacked(
+                    type(DapiProxy).creationCode,
+                    abi.encode(
+                        api3ServerV1,
+                        keccak256(abi.encodePacked(dapiName))
+                    )
+                )
+            )
+        );
+    }
+
+    /// @notice Predicts the address of the data feed proxy with OEV support
+    /// @param dataFeedId Data feed ID
+    /// @param oevBeneficiary OEV beneficiary
+    /// @param metadata Metadata associated with the proxy
+    /// @return proxyAddress Proxy address
+    function predictDataFeedProxyWithOevAddress(
+        bytes32 dataFeedId,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external view override returns (address proxyAddress) {
+        require(dataFeedId != bytes32(0), "Data feed ID zero");
+        require(oevBeneficiary != address(0), "OEV beneficiary zero");
+        proxyAddress = Create2.computeAddress(
+            keccak256(metadata),
+            keccak256(
+                abi.encodePacked(
+                    type(DataFeedProxyWithOev).creationCode,
+                    abi.encode(api3ServerV1, dataFeedId, oevBeneficiary)
+                )
+            )
+        );
+    }
+
+    /// @notice Predicts the address of the dAPI proxy with OEV support
+    /// @param dapiName dAPI name
+    /// @param oevBeneficiary OEV beneficiary
+    /// @param metadata Metadata associated with the proxy
+    /// @return proxyAddress Proxy address
+    function predictDapiProxyWithOevAddress(
+        bytes32 dapiName,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external view override returns (address proxyAddress) {
+        require(dapiName != bytes32(0), "dAPI name zero");
+        require(oevBeneficiary != address(0), "OEV beneficiary zero");
+        proxyAddress = Create2.computeAddress(
+            keccak256(metadata),
+            keccak256(
+                abi.encodePacked(
+                    type(DapiProxyWithOev).creationCode,
+                    abi.encode(
+                        api3ServerV1,
+                        keccak256(abi.encodePacked(dapiName)),
+                        oevBeneficiary
+                    )
+                )
+            )
         );
     }
 }

--- a/contracts/dapis/proxies/ProxyFactory.sol
+++ b/contracts/dapis/proxies/ProxyFactory.sol
@@ -113,11 +113,11 @@ contract ProxyFactory is IProxyFactory {
         );
     }
 
-    /// @notice Predicts the address of the data feed proxy
+    /// @notice Computes the address of the data feed proxy
     /// @param dataFeedId Data feed ID
     /// @param metadata Metadata associated with the proxy
     /// @return proxyAddress Proxy address
-    function predictDataFeedProxyAddress(
+    function computeDataFeedProxyAddress(
         bytes32 dataFeedId,
         bytes calldata metadata
     ) external view override returns (address proxyAddress) {
@@ -133,11 +133,11 @@ contract ProxyFactory is IProxyFactory {
         );
     }
 
-    /// @notice Predicts the address of the dAPI proxy
+    /// @notice Computes the address of the dAPI proxy
     /// @param dapiName dAPI name
     /// @param metadata Metadata associated with the proxy
     /// @return proxyAddress Proxy address
-    function predictDapiProxyAddress(
+    function computeDapiProxyAddress(
         bytes32 dapiName,
         bytes calldata metadata
     ) external view override returns (address proxyAddress) {
@@ -156,12 +156,12 @@ contract ProxyFactory is IProxyFactory {
         );
     }
 
-    /// @notice Predicts the address of the data feed proxy with OEV support
+    /// @notice Computes the address of the data feed proxy with OEV support
     /// @param dataFeedId Data feed ID
     /// @param oevBeneficiary OEV beneficiary
     /// @param metadata Metadata associated with the proxy
     /// @return proxyAddress Proxy address
-    function predictDataFeedProxyWithOevAddress(
+    function computeDataFeedProxyWithOevAddress(
         bytes32 dataFeedId,
         address oevBeneficiary,
         bytes calldata metadata
@@ -179,12 +179,12 @@ contract ProxyFactory is IProxyFactory {
         );
     }
 
-    /// @notice Predicts the address of the dAPI proxy with OEV support
+    /// @notice Computes the address of the dAPI proxy with OEV support
     /// @param dapiName dAPI name
     /// @param oevBeneficiary OEV beneficiary
     /// @param metadata Metadata associated with the proxy
     /// @return proxyAddress Proxy address
-    function predictDapiProxyWithOevAddress(
+    function computeDapiProxyWithOevAddress(
         bytes32 dapiName,
         address oevBeneficiary,
         bytes calldata metadata

--- a/contracts/dapis/proxies/interfaces/IProxyFactory.sol
+++ b/contracts/dapis/proxies/interfaces/IProxyFactory.sol
@@ -50,5 +50,27 @@ interface IProxyFactory {
         bytes calldata metadata
     ) external returns (address proxyAddress);
 
+    function predictDataFeedProxyAddress(
+        bytes32 dataFeedId,
+        bytes calldata metadata
+    ) external view returns (address proxyAddress);
+
+    function predictDapiProxyAddress(
+        bytes32 dapiName,
+        bytes calldata metadata
+    ) external view returns (address proxyAddress);
+
+    function predictDataFeedProxyWithOevAddress(
+        bytes32 dataFeedId,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external view returns (address proxyAddress);
+
+    function predictDapiProxyWithOevAddress(
+        bytes32 dapiName,
+        address oevBeneficiary,
+        bytes calldata metadata
+    ) external view returns (address proxyAddress);
+
     function api3ServerV1() external view returns (address);
 }

--- a/contracts/dapis/proxies/interfaces/IProxyFactory.sol
+++ b/contracts/dapis/proxies/interfaces/IProxyFactory.sol
@@ -50,23 +50,23 @@ interface IProxyFactory {
         bytes calldata metadata
     ) external returns (address proxyAddress);
 
-    function predictDataFeedProxyAddress(
+    function computeDataFeedProxyAddress(
         bytes32 dataFeedId,
         bytes calldata metadata
     ) external view returns (address proxyAddress);
 
-    function predictDapiProxyAddress(
+    function computeDapiProxyAddress(
         bytes32 dapiName,
         bytes calldata metadata
     ) external view returns (address proxyAddress);
 
-    function predictDataFeedProxyWithOevAddress(
+    function computeDataFeedProxyWithOevAddress(
         bytes32 dataFeedId,
         address oevBeneficiary,
         bytes calldata metadata
     ) external view returns (address proxyAddress);
 
-    function predictDapiProxyWithOevAddress(
+    function computeDapiProxyWithOevAddress(
         bytes32 dapiName,
         address oevBeneficiary,
         bytes calldata metadata

--- a/test/dapis/proxies/ProxyFactory.sol.js
+++ b/test/dapis/proxies/ProxyFactory.sol.js
@@ -343,9 +343,9 @@ describe('ProxyFactory', function () {
     });
   });
 
-  describe('predictDataFeedProxyAddress', function () {
+  describe('computeDataFeedProxyAddress', function () {
     context('Data feed ID is not zero', function () {
-      it('predicts data feed proxy address', async function () {
+      it('computes data feed proxy address', async function () {
         const { api3ServerV1, proxyFactory, beaconId } = await helpers.loadFixture(deploy);
         // Precompute the proxy address
         const DataFeedProxy = await artifacts.readArtifact('DataFeedProxy');
@@ -363,23 +363,23 @@ describe('ProxyFactory', function () {
           ethers.utils.keccak256(metadata),
           ethers.utils.keccak256(initcode)
         );
-        expect(await proxyFactory.predictDataFeedProxyAddress(beaconId, metadata)).to.be.equal(proxyAddress);
+        expect(await proxyFactory.computeDataFeedProxyAddress(beaconId, metadata)).to.be.equal(proxyAddress);
       });
     });
     context('Data feed ID is zero', function () {
       it('reverts', async function () {
         const { proxyFactory } = await helpers.loadFixture(deploy);
         const metadata = testUtils.generateRandomBytes();
-        await expect(proxyFactory.predictDataFeedProxyAddress(ethers.constants.HashZero, metadata)).to.be.revertedWith(
+        await expect(proxyFactory.computeDataFeedProxyAddress(ethers.constants.HashZero, metadata)).to.be.revertedWith(
           'Data feed ID zero'
         );
       });
     });
   });
 
-  describe('predictDapiProxyAddress', function () {
+  describe('computeDapiProxyAddress', function () {
     context('dAPI name is not zero', function () {
-      it('predicts dAPI proxy address', async function () {
+      it('computes dAPI proxy address', async function () {
         const { api3ServerV1, proxyFactory, dapiName, dapiNameHash } = await helpers.loadFixture(deploy);
         // Precompute the proxy address
         const DapiProxy = await artifacts.readArtifact('DapiProxy');
@@ -397,24 +397,24 @@ describe('ProxyFactory', function () {
           ethers.utils.keccak256(metadata),
           ethers.utils.keccak256(initcode)
         );
-        expect(await proxyFactory.predictDapiProxyAddress(dapiName, metadata)).to.be.equal(proxyAddress);
+        expect(await proxyFactory.computeDapiProxyAddress(dapiName, metadata)).to.be.equal(proxyAddress);
       });
     });
     context('dAPI name is zero', function () {
       it('reverts', async function () {
         const { proxyFactory } = await helpers.loadFixture(deploy);
         const metadata = testUtils.generateRandomBytes();
-        await expect(proxyFactory.predictDapiProxyAddress(ethers.constants.HashZero, metadata)).to.be.revertedWith(
+        await expect(proxyFactory.computeDapiProxyAddress(ethers.constants.HashZero, metadata)).to.be.revertedWith(
           'dAPI name zero'
         );
       });
     });
   });
 
-  describe('predictDataFeedProxyWithOevAddress', function () {
+  describe('computeDataFeedProxyWithOevAddress', function () {
     context('Data feed ID is not zero', function () {
       context('OEV beneficiary is not zero', function () {
-        it('predicts data feed proxy address', async function () {
+        it('computes data feed proxy address', async function () {
           const { roles, api3ServerV1, proxyFactory, beaconId } = await helpers.loadFixture(deploy);
           // Precompute the proxy address
           const DataFeedProxyWithOev = await artifacts.readArtifact('DataFeedProxyWithOev');
@@ -436,7 +436,7 @@ describe('ProxyFactory', function () {
             ethers.utils.keccak256(initcode)
           );
           expect(
-            await proxyFactory.predictDataFeedProxyWithOevAddress(beaconId, roles.oevBeneficiary.address, metadata)
+            await proxyFactory.computeDataFeedProxyWithOevAddress(beaconId, roles.oevBeneficiary.address, metadata)
           ).to.be.equal(proxyAddress);
         });
       });
@@ -445,7 +445,7 @@ describe('ProxyFactory', function () {
           const { proxyFactory, beaconId } = await helpers.loadFixture(deploy);
           const metadata = testUtils.generateRandomBytes();
           await expect(
-            proxyFactory.predictDataFeedProxyWithOevAddress(beaconId, ethers.constants.AddressZero, metadata)
+            proxyFactory.computeDataFeedProxyWithOevAddress(beaconId, ethers.constants.AddressZero, metadata)
           ).to.be.revertedWith('OEV beneficiary zero');
         });
       });
@@ -455,7 +455,7 @@ describe('ProxyFactory', function () {
         const { roles, proxyFactory } = await helpers.loadFixture(deploy);
         const metadata = testUtils.generateRandomBytes();
         await expect(
-          proxyFactory.predictDataFeedProxyWithOevAddress(
+          proxyFactory.computeDataFeedProxyWithOevAddress(
             ethers.constants.HashZero,
             roles.oevBeneficiary.address,
             metadata
@@ -465,10 +465,10 @@ describe('ProxyFactory', function () {
     });
   });
 
-  describe('predictDapiProxyWithOevAddress', function () {
+  describe('computeDapiProxyWithOevAddress', function () {
     context('Data feed ID is not zero', function () {
       context('OEV beneficiary is not zero', function () {
-        it('predicts data feed proxy address', async function () {
+        it('computes data feed proxy address', async function () {
           const { roles, api3ServerV1, proxyFactory, dapiName, dapiNameHash } = await helpers.loadFixture(deploy);
           // Precompute the proxy address
           const DapiProxyWithOev = await artifacts.readArtifact('DapiProxyWithOev');
@@ -490,7 +490,7 @@ describe('ProxyFactory', function () {
             ethers.utils.keccak256(initcode)
           );
           expect(
-            await proxyFactory.predictDapiProxyWithOevAddress(dapiName, roles.oevBeneficiary.address, metadata)
+            await proxyFactory.computeDapiProxyWithOevAddress(dapiName, roles.oevBeneficiary.address, metadata)
           ).to.be.equal(proxyAddress);
         });
       });
@@ -499,7 +499,7 @@ describe('ProxyFactory', function () {
           const { proxyFactory, beaconId } = await helpers.loadFixture(deploy);
           const metadata = testUtils.generateRandomBytes();
           await expect(
-            proxyFactory.predictDapiProxyWithOevAddress(beaconId, ethers.constants.AddressZero, metadata)
+            proxyFactory.computeDapiProxyWithOevAddress(beaconId, ethers.constants.AddressZero, metadata)
           ).to.be.revertedWith('OEV beneficiary zero');
         });
       });
@@ -509,7 +509,7 @@ describe('ProxyFactory', function () {
         const { roles, proxyFactory } = await helpers.loadFixture(deploy);
         const metadata = testUtils.generateRandomBytes();
         await expect(
-          proxyFactory.predictDapiProxyWithOevAddress(ethers.constants.HashZero, roles.oevBeneficiary.address, metadata)
+          proxyFactory.computeDapiProxyWithOevAddress(ethers.constants.HashZero, roles.oevBeneficiary.address, metadata)
         ).to.be.revertedWith('dAPI name zero');
       });
     });

--- a/test/dapis/proxies/ProxyFactory.sol.js
+++ b/test/dapis/proxies/ProxyFactory.sol.js
@@ -342,4 +342,176 @@ describe('ProxyFactory', function () {
       });
     });
   });
+
+  describe('predictDataFeedProxyAddress', function () {
+    context('Data feed ID is not zero', function () {
+      it('predicts data feed proxy address', async function () {
+        const { api3ServerV1, proxyFactory, beaconId } = await helpers.loadFixture(deploy);
+        // Precompute the proxy address
+        const DataFeedProxy = await artifacts.readArtifact('DataFeedProxy');
+        const initcode = ethers.utils.solidityPack(
+          ['bytes', 'bytes'],
+          [
+            DataFeedProxy.bytecode,
+            ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [api3ServerV1.address, beaconId]),
+          ]
+        );
+        // metadata includes information like coverage policy ID, etc.
+        const metadata = testUtils.generateRandomBytes();
+        const proxyAddress = ethers.utils.getCreate2Address(
+          proxyFactory.address,
+          ethers.utils.keccak256(metadata),
+          ethers.utils.keccak256(initcode)
+        );
+        expect(await proxyFactory.predictDataFeedProxyAddress(beaconId, metadata)).to.be.equal(proxyAddress);
+      });
+    });
+    context('Data feed ID is zero', function () {
+      it('reverts', async function () {
+        const { proxyFactory } = await helpers.loadFixture(deploy);
+        const metadata = testUtils.generateRandomBytes();
+        await expect(proxyFactory.predictDataFeedProxyAddress(ethers.constants.HashZero, metadata)).to.be.revertedWith(
+          'Data feed ID zero'
+        );
+      });
+    });
+  });
+
+  describe('predictDapiProxyAddress', function () {
+    context('dAPI name is not zero', function () {
+      it('predicts dAPI proxy address', async function () {
+        const { api3ServerV1, proxyFactory, dapiName, dapiNameHash } = await helpers.loadFixture(deploy);
+        // Precompute the proxy address
+        const DapiProxy = await artifacts.readArtifact('DapiProxy');
+        const initcode = ethers.utils.solidityPack(
+          ['bytes', 'bytes'],
+          [
+            DapiProxy.bytecode,
+            ethers.utils.defaultAbiCoder.encode(['address', 'bytes32'], [api3ServerV1.address, dapiNameHash]),
+          ]
+        );
+        // metadata includes information like coverage policy ID, etc.
+        const metadata = testUtils.generateRandomBytes();
+        const proxyAddress = ethers.utils.getCreate2Address(
+          proxyFactory.address,
+          ethers.utils.keccak256(metadata),
+          ethers.utils.keccak256(initcode)
+        );
+        expect(await proxyFactory.predictDapiProxyAddress(dapiName, metadata)).to.be.equal(proxyAddress);
+      });
+    });
+    context('dAPI name is zero', function () {
+      it('reverts', async function () {
+        const { proxyFactory } = await helpers.loadFixture(deploy);
+        const metadata = testUtils.generateRandomBytes();
+        await expect(proxyFactory.predictDapiProxyAddress(ethers.constants.HashZero, metadata)).to.be.revertedWith(
+          'dAPI name zero'
+        );
+      });
+    });
+  });
+
+  describe('predictDataFeedProxyWithOevAddress', function () {
+    context('Data feed ID is not zero', function () {
+      context('OEV beneficiary is not zero', function () {
+        it('predicts data feed proxy address', async function () {
+          const { roles, api3ServerV1, proxyFactory, beaconId } = await helpers.loadFixture(deploy);
+          // Precompute the proxy address
+          const DataFeedProxyWithOev = await artifacts.readArtifact('DataFeedProxyWithOev');
+          const initcode = ethers.utils.solidityPack(
+            ['bytes', 'bytes'],
+            [
+              DataFeedProxyWithOev.bytecode,
+              ethers.utils.defaultAbiCoder.encode(
+                ['address', 'bytes32', 'address'],
+                [api3ServerV1.address, beaconId, roles.oevBeneficiary.address]
+              ),
+            ]
+          );
+          // metadata includes information like coverage policy ID, etc.
+          const metadata = testUtils.generateRandomBytes();
+          const proxyAddress = ethers.utils.getCreate2Address(
+            proxyFactory.address,
+            ethers.utils.keccak256(metadata),
+            ethers.utils.keccak256(initcode)
+          );
+          expect(
+            await proxyFactory.predictDataFeedProxyWithOevAddress(beaconId, roles.oevBeneficiary.address, metadata)
+          ).to.be.equal(proxyAddress);
+        });
+      });
+      context('OEV beneficiary is zero', function () {
+        it('reverts', async function () {
+          const { proxyFactory, beaconId } = await helpers.loadFixture(deploy);
+          const metadata = testUtils.generateRandomBytes();
+          await expect(
+            proxyFactory.predictDataFeedProxyWithOevAddress(beaconId, ethers.constants.AddressZero, metadata)
+          ).to.be.revertedWith('OEV beneficiary zero');
+        });
+      });
+    });
+    context('Data feed ID is zero', function () {
+      it('reverts', async function () {
+        const { roles, proxyFactory } = await helpers.loadFixture(deploy);
+        const metadata = testUtils.generateRandomBytes();
+        await expect(
+          proxyFactory.predictDataFeedProxyWithOevAddress(
+            ethers.constants.HashZero,
+            roles.oevBeneficiary.address,
+            metadata
+          )
+        ).to.be.revertedWith('Data feed ID zero');
+      });
+    });
+  });
+
+  describe('predictDapiProxyWithOevAddress', function () {
+    context('Data feed ID is not zero', function () {
+      context('OEV beneficiary is not zero', function () {
+        it('predicts data feed proxy address', async function () {
+          const { roles, api3ServerV1, proxyFactory, dapiName, dapiNameHash } = await helpers.loadFixture(deploy);
+          // Precompute the proxy address
+          const DapiProxyWithOev = await artifacts.readArtifact('DapiProxyWithOev');
+          const initcode = ethers.utils.solidityPack(
+            ['bytes', 'bytes'],
+            [
+              DapiProxyWithOev.bytecode,
+              ethers.utils.defaultAbiCoder.encode(
+                ['address', 'bytes32', 'address'],
+                [api3ServerV1.address, dapiNameHash, roles.oevBeneficiary.address]
+              ),
+            ]
+          );
+          // metadata includes information like coverage policy ID, etc.
+          const metadata = testUtils.generateRandomBytes();
+          const proxyAddress = ethers.utils.getCreate2Address(
+            proxyFactory.address,
+            ethers.utils.keccak256(metadata),
+            ethers.utils.keccak256(initcode)
+          );
+          expect(
+            await proxyFactory.predictDapiProxyWithOevAddress(dapiName, roles.oevBeneficiary.address, metadata)
+          ).to.be.equal(proxyAddress);
+        });
+      });
+      context('OEV beneficiary is zero', function () {
+        it('reverts', async function () {
+          const { proxyFactory, beaconId } = await helpers.loadFixture(deploy);
+          const metadata = testUtils.generateRandomBytes();
+          await expect(
+            proxyFactory.predictDapiProxyWithOevAddress(beaconId, ethers.constants.AddressZero, metadata)
+          ).to.be.revertedWith('OEV beneficiary zero');
+        });
+      });
+    });
+    context('Data feed ID is zero', function () {
+      it('reverts', async function () {
+        const { roles, proxyFactory } = await helpers.loadFixture(deploy);
+        const metadata = testUtils.generateRandomBytes();
+        await expect(
+          proxyFactory.predictDapiProxyWithOevAddress(ethers.constants.HashZero, roles.oevBeneficiary.address, metadata)
+        ).to.be.revertedWith('dAPI name zero');
+      });
+    });
+  });
 });


### PR DESCRIPTION
I figured I'd add this since https://github.com/api3dao/airnode-protocol-v1/pull/119 will require ProxyFactory to be redeployed anyway.

We will have `@api3/contracts` to export a function that predicts what a proxy address will be without deploying it. This address can also be obtained by performing a static call to one of the deployment functions. However, neither of these methods are available if it's a contract that needs to predict the address of a proxy. Instead, the user will have to implement the proxy address prediction function in their contract, and will likely make a mistake while doing (for example I forgot to hash the dAPI name while implementing this and only realized that when the tests reverted, another mistake I foresee is omitting the validations). So these are convenience functions, which also serve a security function.