### PR TITLE
Add Funder contract prototypes

### DIFF
--- a/contracts/utils/Funder.sol
+++ b/contracts/utils/Funder.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+// I wanted to build this in a way that you can also use it to fund 100 sponsor
+// wallets that each power a single self-funded Beacon.
+// Use FunderFactory to deploy.
+contract Funder is Ownable {
+    // Making this immutable would be nice. However, I foresee that we will
+    // want to update this and having to transfer funds to do so will be very
+    // annoying/error-prone.
+    bytes32 public root;
+
+    // This contract is intended to be cloned so the constructor makes the
+    // implementation unusable
+    constructor() {
+        _transferOwnership(address(0));
+        root = bytes32(uint256(1));
+    }
+
+    // Anyone can send ETH to this contract, it can only be used in funding or
+    // withdrawn by the owner
+    receive() external payable {
+        // Maybe emit an event? If the user is withdrawing from an exchange for
+        // example and the exchange hardcodes the gas limit as 21,000, the
+        // event will have that transaction revert. That being said, maybe even
+        // the `receive()` itself causes enough overhead to have this use-case
+        // fail. I will experiment on this.
+    }
+
+    // `initialOwner` can be `address(0)` to make the root immutable and not
+    // allow funds to be withdrawn
+    function initialize(address initialOwner, bytes32 initialRoot) external {
+        require(root == bytes32(0), "Cannot initialize");
+        _transferOwnership(initialOwner);
+        root = initialRoot;
+        // Emit event
+    }
+
+    function setRoot(bytes32 _root) external onlyOwner {
+        require(_root != bytes32(0), "Root zero");
+        root = _root;
+        // Emit event
+    }
+
+    // I figure we may want to skim without disturbing its operation so I added
+    // `amount`
+    function withdraw(address recipient, uint256 amount) external onlyOwner {
+        require(recipient != address(0), "Recipient address zero");
+        require(amount != 0, "Amount zero");
+        require(address(this).balance >= amount, "Insufficient balance");
+        // Emit event
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Transfer unsuccessful");
+    }
+
+    // One can build a layer on top of this to reward accounts that call this.
+    // An even cooler thing to do would be to set `root` so that this function
+    // also funds the reward contract.
+    function fund(
+        bytes32[] calldata proof,
+        address recipient,
+        uint256 lowThreshold,
+        uint256 highThreshold
+    ) external {
+        // Still checking these in case the tree was populated with invalid
+        // values
+        require(recipient != address(0), "Recipient address zero");
+        require(
+            lowThreshold <= highThreshold,
+            "Low threshold higher than high"
+        );
+        require(highThreshold != 0, "High threshold zero");
+        // https://github.com/OpenZeppelin/merkle-tree#validating-a-proof-in-solidity
+        bytes32 leaf = keccak256(
+            bytes.concat(
+                keccak256(abi.encode(recipient, lowThreshold, highThreshold))
+            )
+        );
+        require(MerkleProof.verify(proof, root, leaf), "Invalid proof");
+        // https://en.wikipedia.org/wiki/Hysteresis#In_engineering
+        uint256 recipientBalance = recipient.balance;
+        require(recipientBalance <= lowThreshold, "Balance not low enough");
+        uint256 topUpAmount = highThreshold - recipientBalance <
+            address(this).balance
+            ? highThreshold - recipientBalance
+            : address(this).balance;
+        require(topUpAmount != 0, "Top up amount zero");
+        // Emit event
+        (bool success, ) = recipient.call{value: topUpAmount}("");
+        require(success, "Transfer unsuccessful");
+    }
+}

--- a/contracts/utils/FunderFactory.sol
+++ b/contracts/utils/FunderFactory.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "./Funder.sol";
+import "@openzeppelin/contracts/proxy/Clones.sol";
+
+contract FunderFactory {
+    address public immutable funderImplementation;
+
+    constructor() {
+        funderImplementation = address(new Funder());
+    }
+
+    // This is a bit awkward in that it doesn't allow one to deploy a clone
+    // with the same parameters. However, this is a legit use-case because the
+    // previously deployed Funder may have changed owner and/or root, and the
+    // user needs a Funder with the old parameters again so they need to deploy
+    // with the same parameters. I think the only way to handle this asking for
+    // a salt from the user (as in, a salt to be put in the salt below).
+    function deployFunder(
+        address initialOwner,
+        bytes32 initialRoot
+    ) external returns (address funder) {
+        funder = Clones.cloneDeterministic(
+            funderImplementation,
+            salt(initialOwner, initialRoot)
+        );
+        Funder(payable(funder)).initialize(initialOwner, initialRoot);
+        // Emit event
+    }
+
+    function computeFunderAddress(
+        address initialOwner,
+        bytes32 initialRoot
+    ) external view returns (address funder) {
+        funder = Clones.predictDeterministicAddress(
+            funderImplementation,
+            salt(initialOwner, initialRoot)
+        );
+    }
+
+    function salt(
+        address initialOwner,
+        bytes32 initialRoot
+    ) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(initialOwner, initialRoot));
+    }
+}

--- a/contracts/utils/FunderLite.sol
+++ b/contracts/utils/FunderLite.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// Funder is nice but it may be a bit overkill for funding only two wallets
+contract FunderLite {
+    // Reading these three immutable values is cheaper than reading `root` from
+    // storage
+    address public immutable recipient;
+    uint256 public immutable lowThreshold;
+    uint256 public immutable highThreshold;
+
+    // Deployed normally (is not cloned) to reduce gas cost of funding calls
+    // Do not validate variables to reduce bytecode
+    constructor(
+        address _recipient,
+        uint256 _lowThreshold,
+        uint256 _highThreshold
+    ) {
+        recipient = _recipient;
+        lowThreshold = _lowThreshold;
+        highThreshold = _highThreshold;
+    }
+
+    // Anyone can send ETH to this contract, omitted withdrawal implementation
+    // to reduce bytecode
+    receive() external payable {}
+
+    // No Merkle proofs. Still allows reward mechanism to be built on top.
+    function fund() external {
+        uint256 recipientBalance = recipient.balance;
+        require(recipientBalance <= lowThreshold, "Balance not low enough");
+        uint256 topUpAmount = highThreshold - recipientBalance <
+            address(this).balance
+            ? highThreshold - recipientBalance
+            : address(this).balance;
+        require(topUpAmount != 0, "Top up amount zero");
+        // Emit event
+        (bool success, ) = recipient.call{value: topUpAmount}("");
+        require(success, "Transfer unsuccessful");
+    }
+}


### PR DESCRIPTION
I implemented some contract prototypes for funding sponsor wallets

FunderLite: This is a minimal implementation that is fairly gas-optimized
Funder + FunderFactory: This allows you to fund 100 separate sponsor wallets for each Nodary Beacon (which I think is an actual use-case)

I provided FunderLite in case you find Funder too heavy for dAPIs team use-case. However, considering `lowThreshold` and `highThreshold` will be fairly different (so `fund()` will be called fairly infrequently and it being heavy doesn't matter that much) and it's better to have one funding solution that we perfect, I think Funder can also be used for dAPI purposes.

Goes without saying but this contract can also be used to fund RRP sponsor wallets, for example for QRNG.